### PR TITLE
Update limit date logic for start and end date picker

### DIFF
--- a/src/components/comparison-filter-modal/comparison-filter-modal.vue
+++ b/src/components/comparison-filter-modal/comparison-filter-modal.vue
@@ -92,7 +92,7 @@
                       id="start"
                       v-model="startDate"
                       type="date"
-                      :max="endDate || undefined"
+                      :max="today"
                       class="bg-white text-black rounded-lg mr-2"
                     >
                   </div>
@@ -107,7 +107,6 @@
                       id="end"
                       v-model="endDate"
                       type="date"
-                      :min="startDate || undefined"
                       :max="today"
                       class="bg-white text-black rounded-lg mr-2"
                     >


### PR DESCRIPTION
## ✅ DoD

- [x] Resolves limit date logic for start and end date picker
- [x] Documentation na
- [x] CHANGELOG na

## 📝 Summary

- Update limit date logic for start and end date picker by setting the maximum date to today for both start and end date picker and remove minimum date logic from end date picker.

## 💉 Testing

- User can select any date until today freely on both start and end date picker

## 🛑 Problems

- None

## 💡 More ideas

- None

## 📸 Screenshots

![image](https://user-images.githubusercontent.com/44169425/135063146-fd95f571-4290-48b3-86ab-69771f33ecd5.png)

## 🙋 Reviewer Guidance

- Please to be sure that we are going with logic to allow the user to select start date greater than end date.
