### PR TITLE
[Refactor] Auth is always ready (we await in main)

### DIFF
--- a/packages/website/src/_services/auth/auth-required-guard.ts
+++ b/packages/website/src/_services/auth/auth-required-guard.ts
@@ -5,7 +5,7 @@ import { useAuthClient } from '~/auth'
 export const authRequiredGuard: NavigationGuardWithThis<undefined> = async (to: RouteLocationNormalized, from: RouteLocationNormalized, next: NavigationGuardNext) => {
   // Already authenticated
   const authClient = useAuthClient()
-  if (await authClient.isReady() && authClient.isAuthenticated) return next()
+  if (authClient.isAuthenticated) return next()
 
   // Redirect to login
   next(false)


### PR DESCRIPTION
## 📝 Summary

### PBIs:
- Resolves _N/A_

### Description:

I realized that the auth-guard only checks the state of `isReady()` when a navigation occurs (the guard is created & set before this, but not called). Navigation only happens after the router is mounted. Since we `await auth.init(...)` before mounting the router, auth is *always* ready before the guard function is fired (and all the watch/await logic is nonsense).

I have manually tested:
- Already logged in & load a URL
- Logged out & load a protected URL => redirect to login
- Logged out & load a public URL => press logic manually

## 🙋 Requests for feedback

- @Nutto55, @naluinui - Please check I'm not going crazy? Maybe you could test that it still works for you?

## ✅ DoD

- [x] Tested & no regression (MANUAL)
- [x] Respects SRP
- [x] `// TODO XYZ` all resolved
- [x] PBIs created for deferred work
- [x] Documented (N/A)