### PR TITLE
Change the data type for the photo_url column

### DIFF
--- a/apps/cli/src/db/migrations/220729-01-update-taxon-species-photo.ts
+++ b/apps/cli/src/db/migrations/220729-01-update-taxon-species-photo.ts
@@ -1,0 +1,23 @@
+/**
+ * WARNING: MIGRATIONS ARE IMMUTABLE
+ * Do not depend on imported code which may change
+ */
+
+import { DataTypes, QueryInterface } from 'sequelize'
+import { MigrationFn } from 'umzug'
+
+const TABLE_NAME = 'taxon_species_photo'
+
+export const up: MigrationFn<QueryInterface> = async (params): Promise<unknown> => {
+  return await params.context.changeColumn(TABLE_NAME, 'photo_url', {
+    type: DataTypes.TEXT,
+    allowNull: false
+  })
+}
+
+export const down: MigrationFn<QueryInterface> = async (params) => {
+  return await params.context.changeColumn(TABLE_NAME, 'photo_url', {
+    type: DataTypes.STRING(511),
+    allowNull: false
+  })
+}

--- a/apps/website/src/_services/feature-toggles/index.ts
+++ b/apps/website/src/_services/feature-toggles/index.ts
@@ -6,7 +6,7 @@ const featureTogglesRaw = {
   // Example:
   // showActivityLineChart: import.meta.env.VITE_TOGGLE_SHOW_ACTIVITY_LINE_CHART
 
-  logoPride: import.meta.env.VITE_TOGGLE_LOGO_PRIDE,
+  logoPride: import.meta.env.VITE_TOGGLE_LOGO_PRIDE
   /* STOP: Declare toggles here */
 }
 

--- a/packages/common/src/dao/models/taxon-species-photo-model.ts
+++ b/packages/common/src/dao/models/taxon-species-photo-model.ts
@@ -21,7 +21,7 @@ export const TaxonSpeciesPhotoModel = defineWithDefaults<TaxonSpeciesPhoto>(
     },
 
     // Facts
-    photoUrl: DataTypes.STRING(511), // https://upload.wikimedia.org/wikipedia/commons/thumb/b/b1/Puerto_Rican_Sharp-shinned_hawk_sitting_on_tree_branch.jpg/268px-Puerto_Rican_Sharp-shinned_hawk_sitting_on_tree_branch.jpg
+    photoUrl: DataTypes.TEXT, // https://upload.wikimedia.org/wikipedia/commons/thumb/b/b1/Puerto_Rican_Sharp-shinned_hawk_sitting_on_tree_branch.jpg/268px-Puerto_Rican_Sharp-shinned_hawk_sitting_on_tree_branch.jpg
     photoCaption: DataTypes.STRING(255), // Puerto Rican sharp-shinned hawk
     photoAuthor: DataTypes.STRING(255), // Mike Morel/U. S. Fish and Wildlife Service
     photoLicense: DataTypes.STRING(255), // Public domain


### PR DESCRIPTION
I've created this branch from the master branch, because a lot of updates on the staging side.

We have to fix this issue, which we get from kubernetes log file:

```
name: 'SequelizeDatabaseError',
parent: error: value too long for type character varying(511)

  sql: `INSERT INTO "taxon_species_photo" ("taxon_species_id","source","photo_url","photo_caption","photo_author","photo_license","photo_license_url","created_at","updated_at") VALUES (1,'WIKI','https://upload.wikimedia.org/wikipedia/commons/thumb/4/4a/Eleutherodactylus_brittoni_front_view.jpg/320px-Eleutherodactylus_brittoni_front_view.jpg','Grass coqui','Meowmeow10','CC BY-SA 3.0','https://en.wikipedia.org/wiki/Grass_coqui#/media/File:Eleutherodactylus_brittoni_front_view.jpg','2022-07-29 08:03:29.734 +00:00','2022-07-29 08:03:29.734 +00:00'),(2,'WIKI','https://upload.wikimedia.org/wikipedia/commons/thumb/a/aa/Leptodactylus_albilabris.jpg/320px-Leptodactylus_albilabris.jpg','Leptodactylus albilabris','','Public domain','https://en.wikipedia.org/wiki/Leptodactylus_albilabris#/media/File:Leptodactylus_albilabris.jpg','2022-07-29 08:03:29.734 +00:00','2022-07-29 08:03:29.734 +00:00'),(3,'WIKI','https://upload.wikimedia.org/wikipedia/commons/c/ce/Common_Coqu%C3%AD.jpg','Common coquí','United States Department of Agriculture','Public domain','https://en.wikipedia.org/wiki/Common_coqu%C3%AD#/media/File:Common_Coqu%C3%AD.jpg','2022-07-29 08:03:29.734 +00:00','2022-07-29 08:03:29.734 +00:00'),(4,'WIKI','https://upload.wikimedia.org/wikipedia/commons/thumb/8/87/CoquiLlanero.jpg/320px-CoquiLlanero.jpg','Eleutherodactylus juanariveroi','USFWS','Public domain','https://en.wikipedia.org/wiki/Eleutherodactylus_juanariveroi#/media/File:CoquiLlanero.jpg','2022-07-29 08:03:29.734 +00:00','2022-07-29 08:03:29.734 +00:00'),(6,'WIKI','https://upload.wikimedia.org/wikipedia/commons/thumb/f/f2/Tyrannus_dominicensis_103778882_%28cropped%29.jpg/187px-Tyrannus_dominicensis_103778882_%28cropped%29.jpg','Gray kingbird','Aitor','CC BY 4.0','https://en.wikipedia.org/wiki/Gray_kingbird#/media/File:Tyrannus_dominicensis_103778882_%28cropped%29.jpg','2022-07-29 08:03:29.734 +00:00','2022-07-29 08:03:29.734 +00:00'),(7,'WIKI','https://upload.wikimedia.org/wikipedia/commons/thumb/f/f8/Dendroica_adelaidae.jpg/320px-Dendroica_adelaidae.jpg','Adelaide''s warbler','Jaro Nemčok','CC BY-SA 3.0','https://en.wikipedia.org/wiki/Adelaide''s_warbler#/media/File:Dendroica_adelaidae.jpg','2022-07-29 08:03:29.734 +00:00','2022-07-29 08:03:29.734 +00:00'),(8,'WIKI','https://upload.wikimedia.org/wikipedia/commons/thumb/b/bf/PigFrog_Gam.jpg/320px-PigFrog_Gam.jpg','Pig frog','MarshBunny','CC BY-SA 4.0','https://en.wikipedia.org/wiki/Pig_frog#/media/File:PigFrog_Gam.jpg','2022-07-29 08:03:29.734 +00:00','2022-07-29 08:03:29.734 +00:00'),(9,'WIKI','https://upload.wikimedia.org/wikipedia/commons/thumb/2/27/Smooth-billed_ani_%28Crotophaga_ani%29_GC.JPG/320px-Smooth-billed_ani_%28Crotophaga_ani%29_GC.JPG','Smooth-billed ani','Charles J. Sharp','CC BY-SA 4.0','https://en.wikipedia.org/wiki/Smooth-billed_ani#/media/File:Smooth-billed_ani_%28Crotophaga_ani%29_GC.JPG','2022-07-29 08:03:29.734 +00:00','2022-07-29 08:03:29.734 +00:00'),(10,'WIKI','https://upload.wikimedia.org/wikipedia/commons/thumb/9/9a/Limpkin%2C_Florida_05.jpg/320px-Limpkin%2C_Florida_05.jpg','Limpkin','VJAnderson','CC BY-SA 4.0','https://en.wikipedia.org/wiki/Limpkin#/media/File:Limpkin%2C_Florida_05.jpg','2022-07-29 08:03:29.734 +00:00','2022-07-29 08:03:29.734 +00:00'),(11,'WIKI','https://upload.wikimedia.org/wikipedia/commons/thumb/e/ef/Killdeer.jpg/320px-Killdeer.jpg','Killdeer','Alan D. Wilson','CC BY-SA 3.0','https://en.wikipedia.org/wiki/Killdeer#/media/File:Killdeer.jpg','2022-07-29 08:03:29.734 +00:00','2022-07-29 08:03:29.734 +00:00'),(12,'WIKI','https://upload.wikimedia.org/wikipedia/commons/thumb/5/5c/Monk_Parakeet_%28Myiopsitta_monachus%29_%2828420470712%29.jpg/320px-Monk_Parakeet_%28Myiopsitta_monachus%29_%2828420470712%29.jpg','Monk parakeet','Bernard DUPONT from FRANCE','CC BY-SA 2.0','https://en.wikipedia.org/wiki/Monk_parakeet#/media/File:Monk_Parakeet_%28Myiopsitta_monachus%29_%2828420470712%29.jpg','2022-07-29 08:03:29.734 +00:00','2022-07-29 08:03:29.734 +00:00'),(13,'WIKI','https://upload.wikimedia.org/wikipedia/commons/thumb/8/88/Megascops_nudipes-Mucarito-Screech_Owl_of_Puerto_Rico.jpeg/268px-Megascops_nudipes-Mucarito-Screech_Owl_of_Puerto_Rico.jpeg','Puerto Rican owl','Efeliciano ms','CC BY-SA 4.0','https://en.wikipedia.org/wiki/Puerto_Rican_owl#/media/File:Megascops_nudipes-Mucarito-Screech_Owl_of_Puerto_Rico.jpeg','2022-07-29 08:03:29.734 +00:00','2022-07-29 08:03:29.734 +00:00'),(14,'WIKI','https://upload.wikimedia.org/wikipedia/commons/thumb/e/e2/Puerto_Rican_Woodpecker_%28Melanerpes_portoricensis%29.jpg/213px-Puerto_Rican_Woodpecker_%28Melanerpes_portoricensis%29.jpg','Puerto Rican woodpecker','Ryan Douglas','CC BY 3.0','https://en.wikipedia.org/wiki/Puerto_Rican_woodpecker#/media/File:Puerto_Rican_Woodpecker_%28Melanerpes_portoricensis%29.jpg','2022-07-29 08:03:29.734 +00:00','2022-07-29 08:03:29.734 +00:00'),(15,'WIKI','https://upload.wikimedia.org/wikipedia/commons/thumb/d/dd/Red-legged_thrush_%28Turdus_plumbeus_rubripes%29.JPG/320px-Red-legged_thrush_%28Turdus_plumbeus_rubripes%29.JPG','Red-legged thrush','Charles J. Sharp','CC BY-SA 4.0','https://en.wikipedia.org/wiki/Red-legged_thrush#/media/File:Red-legged_thrush_%28Turdus_plumbeus_rubripes%29.JPG','2022-07-29 08:03:29.734 +00:00','2022-07-29 08:03:29.734 +00:00'),(16,'WIKI','https://upload.wikimedia.org/wikipedia/commons/thumb/1/14/Yellow-faced-grassquit-eating-seeds.jpg/320px-Yellow-faced-grassquit-eating-seeds.jpg','Yellow-faced grassquit','Tony Northrup','CC BY 3.0','https://en.wikipedia.org/wiki/Yellow-faced_grassquit#/media/File:Yellow-faced-grassquit-eating-seeds.jpg','2022-07-29 08:03:29.734 +00:00','2022-07-29 08:03:29.734 +00:00'),(17,'WIKI','https://upload.wikimedia.org/wikipedia/commons/thumb/6/69/Black-faced_grassquit_%28Tiaris_bicolor%29_male.jpg/320px-Black-faced_grassquit_%28Tiaris_bicolor%29_male.jpg','Black-faced grassquit','Charles J. Sharp','CC BY-SA 4.0','https://en.wikipedia.org/wiki/Black-faced_grassquit#/media/File:Black-faced_grassquit_%28Tiaris_bicolor%29_male.jpg','2022-07-29 08:03:29.734 +00:00','2022-07-29 08:03:29.734 +00:00'),(20,'WIKI','https://upload.wikimedia.org/wikipedia/commons/thumb/b/b1/Tinamus_majorPCSL00504B.jpg/320px-Tinamus_majorPCSL00504B.jpg','Great tinamou','Patrick Coin (Patrick Coin)','CC BY-SA 2.5','https://en.wikipedia.org/wiki/Great_tinamou#/media/File:Tinamus_majorPCSL00504B.jpg','2022-07-29 08:03:29.734 +00:00','2022-07-29 08:03:29.734 +00:00'),(21,'WIKI','https://upload.wikimedia.org/wikipedia/commons/thumb/b/b5/Bananaquits.jpg/320px-Bananaquits.jpg','Bananaquit','Leon-bojarczuk - Flickr page','CC BY-SA 2.0','https://en.wikipedia.org/wiki/Bananaquit#/media/File:Bananaquits.jpg','2022-07-29 08:03:29.734 +00:00','2022-07-29 08:03:29.734 +00:00'),(22,'WIKI','https://upload.wikimedia.org/wikipedia/commons/thumb/7/72/Tao001_edit_crop.jpg/320px-Tao001_edit_crop.jpg','Grey tinamou','Livaldo (talk; contribs)','Public domain','https://en.wikipedia.org/wiki/Grey_tinamou#/media/File:Tao001_edit_crop.jpg','2022-07-29 08:03:29.734 +00:00','2022-07-29 08:03:29.734 +00:00'),(23,'WIKI','https://upload.wikimedia.org/wikipedia/commons/thumb/5/5c/Crypturellus_soui.jpg/320px-Crypturellus_soui.jpg','Little tinamou','','CC-BY-SA-3.0','https://en.wikipedia.org/wiki/Little_tinamou#/media/File:Crypturellus_soui.jpg','2022-07-29 08:03:29.734 +00:00','2022-07-29 08:03:29.734 +00:00'),(24,'WIKI','https://upload.wikimedia.org/wikipedia/commons/thumb/b/b9/Crypturellus_obsoletus.jpg/320px-Crypturellus_obsoletus.jpg','Brown tinamou','','CC-BY-SA-3.0','https://en.wikipedia.org/wiki/Brown_tinamou#/media/File:Crypturellus_obsoletus.jpg','2022-07-29 08:03:29.734 +00:00','2022-07-29 08:03:29.734 +00:00'),(25,'WIKI','https://upload.wikimedia.org/wikipedia/commons/thumb/b/b9/Penelope_jacquacu_-Manu_National_Park%2C_Peru-8.jpg/213px-Penelope_jacquacu_-Manu_National_Park%2C_Peru-8.jpg','Spix''s guan','Patty Ho','CC BY 2.0','https://en.wikipedia.org/wiki/Spix''s_guan#/media/File:Penelope_jacquacu_-Manu_National_Park%2C_Peru-8.jpg','2022-07-29 08:03:29.734 +00:00','2022-07-29 08:03:29.734 +00:00'),(26,'WIKI','https://upload.wikimedia.org/wikipedia/commons/thumb/f/f9/Pipile_cumanensis_%28Denver_Zoo%292.jpg/320px-Pipile_cumanensis_%28Denver_Zoo%292.jpg','Blue-throated piping guan','Common_Piping_Guan_aburris_pipile.jpg: Drew Avery\n` +
      '\n' +
      "derivative work: Donkey shot (talk)','CC BY-SA 3.0','https://en.wikipedia.org/wiki/Blue-throated_piping_guan#/media/File:Pipile_cumanensis_%28Denver_Zoo%292.jpg','2022-07-29 08:03:29.734 +00:00','2022-07-29 08:03:29.734 +00:00'),(27,'WIKI','https://upload.wikimedia.org/wikipedia/commons/thumb/3/37/Odontophorus_stellatus.jpg/320px-Odontophorus_stellatus.jpg','Starred wood quail','John Gould (1804-1881)','Public domain','https://en.wikipedia.org/wiki/Starred_wood_quail#/media/File:Odontophorus_stellatus.jpg','2022-07-29 08:03:29.734 +00:00','2022-07-29 08:03:29.734 +00:00'),(28,'WIKI','https://upload.wikimedia.org/wikipedia/commons/thumb/e/ed/Red-throated_Caracara.jpg/320px-Red-throated_Caracara.jpg','Red-throated caracara','Sean McCann','CC BY-SA 3.0','https://en.wikipedia.org/wiki/Red-throated_caracara#/media/File:Red-throated_Caracara.jpg','2022-07-29 08:03:29.734 +00:00','2022-07-29 08:03:29.734 +00:00'),(29,'WIKI','https://upload.wikimedia.org/wikipedia/commons/thumb/2/2f/Micrastur_ruficollis_-Parque_Estadual_da_Serra_da_Cantareira%2C_Sao_Paulo%2C_Brazil-8.jpg/233px-Micrastur_ruficollis_-Parque_Estadual_da_Serra_da_Cantareira%2C_Sao_Paulo%2C_Brazil-8.jpg','Barred forest falcon','Dario Sanches','CC BY-SA 2.0','https://en.wikipedia.org/wiki/Barred_forest_falcon#/media/File:Micrastur_ruficollis_-Parque_Estadual_da_Serra_da_Cantareira%2C_Sao_Paulo%2C_Brazil-8.jpg','2022-07-29 08:03:29.734 +00:00','2022-07-29 08:03:29.734 +00:00'),(30,'WIKI','https://upload.wikimedia.org/wikipedia/commons/thumb/e/ec/Micrastur_semitorquatus.jpg/308px-Micrastur_semitorquatus.jpg','Collared forest falcon','Dominic Sherony','CC BY-SA 2.0','https://en.wikipedia.org/wiki/Collared_forest_falcon#/media/File:M"... 810551 more characters,
    parameters: undefined
  },
  original: error: value too long for type character varying(511)

```