### PR TITLE
#866 User can be able to press Ctrl to able to partially select multiple detections

### DIFF
--- a/apps/website/src/detect/cnn-job-detail/components/detection-item.vue
+++ b/apps/website/src/detect/cnn-job-detail/components/detection-item.vue
@@ -68,6 +68,7 @@ import { inject, onBeforeUnmount, onMounted, ref, watch, withDefaults } from 'vu
 import { apiBioGetCoreMedia } from '@rfcx-bio/common/api-bio/core-proxy/core-media'
 
 import { apiClientBioKey } from '@/globals'
+import { DetectionEvent } from './types'
 import ValidationStatus from './validation-status.vue'
 
 const props = withDefaults(defineProps<{
@@ -83,7 +84,7 @@ const props = withDefaults(defineProps<{
   checked: null
 })
 
-const emit = defineEmits<{(e: 'emitDetection', detectionId: number, isSelected: boolean, isShiftKeyHolding: boolean): void}>()
+const emit = defineEmits<{(e: 'emitDetection', detectionId: number, event: DetectionEvent): void}>()
 
 const spectrogramLoading = ref(false)
 const audioLoading = ref(false)
@@ -157,8 +158,11 @@ const stop = () => {
 const toggleDetection = (event: MouseEvent) => {
   isSelected.value = !isSelected.value
   if (props.id === null) return
-  const isShiftKeyHolding = event.shiftKey
-  emit('emitDetection', props.id, isSelected.value, isShiftKeyHolding)
+  emit('emitDetection', props.id, {
+    isSelected: isSelected.value,
+    isShiftKeyHolding: event.shiftKey,
+    isCtrlKeyHolding: event.ctrlKey || event.metaKey
+  })
 }
 
 </script>

--- a/apps/website/src/detect/cnn-job-detail/components/job-detections.vue
+++ b/apps/website/src/detect/cnn-job-detail/components/job-detections.vue
@@ -47,7 +47,7 @@ import { useRoute } from 'vue-router'
 import { ROUTE_NAMES } from '~/router'
 import DetectionItem from './detection-item.vue'
 import DetectionValidator from './detection-validator.vue'
-import { DetectionMedia, DetectionValidationStatus } from './types'
+import { DetectionEvent, DetectionMedia, DetectionValidationStatus } from './types'
 
 const MAX_DISPLAY_PER_EACH_SPECIES = 20
 
@@ -60,14 +60,22 @@ const filterOptions: DetectionValidationStatus[] = [
 
 const validationCount = ref<number | null>(null)
 const isOpen = ref<boolean | null>(null)
-const isShiftKeyHolding = ref<boolean>(false)
+const isShiftHolding = ref<boolean>(false)
+const isCtrlHolding = ref<boolean>(false)
 const currentDetectionId = ref<number | undefined>(undefined)
 
 const route = useRoute()
 const jobId = computed(() => route.params.jobId)
 
-watch(() => isShiftKeyHolding.value, (newVal, oldVal) => {
-  if (newVal !== oldVal && isShiftKeyHolding.value === false) {
+watch(() => isShiftHolding.value, (newVal, oldVal) => {
+  if (newVal !== oldVal && isShiftHolding.value === false) {
+    resetSelection(currentDetectionId.value)
+    validationCount.value = getValidationCount()
+  }
+})
+
+watch(() => isCtrlHolding.value, (newVal, oldVal) => {
+  if (newVal !== oldVal && isCtrlHolding.value === false) {
     resetSelection(currentDetectionId.value)
     validationCount.value = getValidationCount()
   }
@@ -102,11 +110,13 @@ const displaySpecies = (media: DetectionMedia[]) => {
   return media.slice(0, Math.min(media.length, MAX_DISPLAY_PER_EACH_SPECIES))
 }
 
-const updateSelectedDetections = (detectionId: number, isSelected: boolean, isShiftHolding: boolean) => {
+const updateSelectedDetections = (detectionId: number, event: DetectionEvent) => {
+  const { isSelected, isShiftKeyHolding, isCtrlKeyHolding } = event
   selectDetection(detectionId, isSelected)
   currentDetectionId.value = detectionId
-  isShiftKeyHolding.value = isShiftHolding
-  if (isShiftKeyHolding.value) {
+  isShiftHolding.value = isShiftKeyHolding
+  isCtrlHolding.value = isCtrlKeyHolding
+  if (isShiftHolding.value) {
     const combinedDetections = getCombinedDetections()
     const selectedDetectionIds = getSelectedDetectionIds()
     const firstInx = combinedDetections.findIndex(d => d.id === selectedDetectionIds[0])

--- a/apps/website/src/detect/cnn-job-detail/components/types.ts
+++ b/apps/website/src/detect/cnn-job-detail/components/types.ts
@@ -19,3 +19,9 @@ export interface DetectionValidationStatus {
   label: string
   checked: boolean
 }
+
+export interface DetectionEvent {
+  isSelected: boolean
+  isShiftKeyHolding: boolean
+  isCtrlKeyHolding: boolean
+}


### PR DESCRIPTION
## ✅ DoD

- [x] Resolves #866 
- [x] Release notes updated
- [x] Test notes na
- [x] Deployment notes na
- [x] DB migrations na

## 📝 Summary

User can be able to press Ctrl to able to partially select multiple detections (item A, C, G)

[x] User select item 1 then hold ctrl / command keyboard and select item 4, the selected item should be 1, 4
[x] If the user already selected 1,4 then click on item 5 while holding ctrl / command the selected item should be 1,4,5
[x] If the user already selected 1,4 then click on item 1 while holding ctrl / command then it should unselect item 1 == the selected item will be 4
[x] If the user already selected 1,4 then release the ctrl / command and select item 5 then the selected item should be 5

## 📸 Screenshots


https://user-images.githubusercontent.com/31901584/208135772-7a9ef0d2-e2c6-4bcb-beb7-44e425acbad8.mov



## 🛑 Problems

- Write any discovered & unresolved problems

## 💡 More ideas

Write any more ideas you have