### PR TITLE
Swap `Not Evaluated` IUCN status with `Not Available` when we don't get the status from IUCN 

### DIFF
--- a/apps/cli/src/db/seeders/_data/risk-rating.ts
+++ b/apps/cli/src/db/seeders/_data/risk-rating.ts
@@ -1,8 +1,8 @@
 import { type RiskRatingIucn } from '@rfcx-bio/common/dao/types'
 
 export const rawRiskRatings: RiskRatingIucn[] = [
-  { id: -1, code: 'NE', isThreatened: false },
-  { id: 0, code: 'NA', isThreatened: false },
+  { id: -1, code: 'NA', isThreatened: false },
+  { id: 0, code: 'NE', isThreatened: false },
   { id: 100, code: 'DD', isThreatened: false },
   { id: 200, code: 'LC', isThreatened: false },
   { id: 300, code: 'NT', isThreatened: true },

--- a/apps/cli/src/sync/species-info/iucn.int.test.ts
+++ b/apps/cli/src/sync/species-info/iucn.int.test.ts
@@ -130,7 +130,7 @@ test('rows created for non-matching species', async () => {
   // Assert
   const iucnSpecies3 = await models.TaxonSpeciesIucn.findOne({ where: { taxonSpeciesId: SPECIES_3.id } })
   expect(iucnSpecies3).toBeTruthy()
-  expect(iucnSpecies3?.riskRatingIucnId).toBe(iucnCategoryToRiskRatingId.NE) // TODO: should be 'unknown' instead of NE
+  expect(iucnSpecies3?.riskRatingIucnId).toBe(iucnCategoryToRiskRatingId.NA)
 })
 
 test('risk rating not updated when IUCN data not found', async () => {

--- a/apps/website/src/_services/risk-ratings/index.ts
+++ b/apps/website/src/_services/risk-ratings/index.ts
@@ -9,8 +9,8 @@ export interface RiskRatingUi {
  */
 export const DEFAULT_RISK_RATING_ID = -1
 export const RISKS_BY_ID: Record<number, RiskRatingUi> = {
-  [DEFAULT_RISK_RATING_ID]: { code: 'NE', label: 'Not Evaluated', color: '#AAAAAA' },
-  0: { code: 'NA', label: 'Not Applicable', color: '#888888' },
+  [DEFAULT_RISK_RATING_ID]: { code: 'NA', label: 'Not Available', color: '#AAAAAA' },
+  0: { code: 'NE', label: 'Not Evaluated', color: '#888888' },
   100: { code: 'DD', label: 'Data Deficient', color: '#755F85' },
   200: { code: 'LC', label: 'Least Concern', color: '#2F6E61' },
   300: { code: 'NT', label: 'Near Threatened', color: '#5F9E61' },

--- a/packages/common/src/dao/master-data/risk-rating.ts
+++ b/packages/common/src/dao/master-data/risk-rating.ts
@@ -3,8 +3,8 @@ import { type ValueOf } from '@rfcx-bio/utils/utility-types'
 import { type RiskRatingIucn } from '@/dao/types'
 
 export const masterRiskRatings = {
-  NE: { id: -1, code: 'NE', isThreatened: false, isProtected: false },
-  NA: { id: 0, code: 'NA', isThreatened: false, isProtected: false },
+  NE: { id: -1, code: 'NA', isThreatened: false, isProtected: false },
+  NA: { id: 0, code: 'NE', isThreatened: false, isProtected: false },
   DD: { id: 100, code: 'DD', isThreatened: false, isProtected: false },
   LC: { id: 200, code: 'LC', isThreatened: false, isProtected: false },
   NT: { id: 300, code: 'NT', isThreatened: true, isProtected: false },


### PR DESCRIPTION
fixes #1031 

## Description
This PR fixes the problem when the sync job runs and cannot find the data from IUCN API. Previously it will set the IUCN Code to `NE` from `Not Evaluated`. This PR swaps the `NE` status to `NA` in several places.

## Test result
The test command I use in the image:
```
cd apps/cli
pnpm -r clean
pnpm -w serve-int
pnpm exec cross-env BIO_DB_PORT=5434 vitest --no-threads src/sync/species-info/iucn.int.test.ts
```
![image](https://github.com/rfcx/biodiversity-analytics/assets/60266519/012b7b9a-7611-43a4-9e7c-979727d4e278)

## Concerns
- I don't know whether I need to do the migration.
- The test that fails in the CI Nightly actions still occurs when executing `pnpm test`.