### PR TITLE
Change risk rating status from `NA` to `NL`

### DIFF
--- a/apps/cli/src/db/seeders/_data/risk-rating.ts
+++ b/apps/cli/src/db/seeders/_data/risk-rating.ts
@@ -1,7 +1,7 @@
 import { type RiskRatingIucn } from '@rfcx-bio/common/dao/types'
 
 export const rawRiskRatings: RiskRatingIucn[] = [
-  { id: -1, code: 'NA', isThreatened: false },
+  { id: -1, code: 'NL', isThreatened: false },
   { id: 0, code: 'NE', isThreatened: false },
   { id: 100, code: 'DD', isThreatened: false },
   { id: 200, code: 'LC', isThreatened: false },

--- a/apps/cli/src/sync/species-info/iucn.int.test.ts
+++ b/apps/cli/src/sync/species-info/iucn.int.test.ts
@@ -130,7 +130,7 @@ test('rows created for non-matching species', async () => {
   // Assert
   const iucnSpecies3 = await models.TaxonSpeciesIucn.findOne({ where: { taxonSpeciesId: SPECIES_3.id } })
   expect(iucnSpecies3).toBeTruthy()
-  expect(iucnSpecies3?.riskRatingIucnId).toBe(iucnCategoryToRiskRatingId.NA)
+  expect(iucnSpecies3?.riskRatingIucnId).toBe(iucnCategoryToRiskRatingId.NL)
 })
 
 test('risk rating updated after 1 month', async () => {

--- a/apps/website/src/_services/risk-ratings/index.ts
+++ b/apps/website/src/_services/risk-ratings/index.ts
@@ -9,7 +9,7 @@ export interface RiskRatingUi {
  */
 export const DEFAULT_RISK_RATING_ID = -1
 export const RISKS_BY_ID: Record<number, RiskRatingUi> = {
-  [DEFAULT_RISK_RATING_ID]: { code: 'NA', label: 'Not Available', color: '#AAAAAA' },
+  [DEFAULT_RISK_RATING_ID]: { code: 'NL', label: 'Not Listed', color: '#AAAAAA' },
   0: { code: 'NE', label: 'Not Evaluated', color: '#888888' },
   100: { code: 'DD', label: 'Data Deficient', color: '#755F85' },
   200: { code: 'LC', label: 'Least Concern', color: '#2F6E61' },

--- a/packages/common/src/dao/master-data/risk-rating.ts
+++ b/packages/common/src/dao/master-data/risk-rating.ts
@@ -3,8 +3,8 @@ import { type ValueOf } from '@rfcx-bio/utils/utility-types'
 import { type RiskRatingIucn } from '@/dao/types'
 
 export const masterRiskRatings = {
-  NE: { id: -1, code: 'NA', isThreatened: false, isProtected: false },
-  NA: { id: 0, code: 'NE', isThreatened: false, isProtected: false },
+  NL: { id: -1, code: 'NL', isThreatened: false, isProtected: false },
+  NE: { id: 0, code: 'NE', isThreatened: false, isProtected: false },
   DD: { id: 100, code: 'DD', isThreatened: false, isProtected: false },
   LC: { id: 200, code: 'LC', isThreatened: false, isProtected: false },
   NT: { id: 300, code: 'NT', isThreatened: true, isProtected: false },

--- a/packages/common/src/dao/types/risk-rating-iucn.ts
+++ b/packages/common/src/dao/types/risk-rating-iucn.ts
@@ -1,4 +1,4 @@
-type RiskCode = 'NE' | 'NA' | 'DD' | 'LC' | 'NT' | 'VU' | 'EN' | 'CR' | 'RE' | 'EW' | 'EX'
+type RiskCode = 'NL' | 'NE' | 'DD' | 'LC' | 'NT' | 'VU' | 'EN' | 'CR' | 'RE' | 'EW' | 'EX'
 
 export interface RiskRatingIucn {
   id: number


### PR DESCRIPTION
fixes #1049 

## Changes
This PR changes the default risk rating status from `NA` (Not Available) to `NL` (Not Listed). Most of the changes are just reverting #1033 stuff to NL.

## Testing

The test is ran by using this set of commands.
```
cd apps/cli
pnpm -r clean
pnpm -w serve-int
pnpm exec cross-env BIO_DB_PORT=5434 vitest --no-threads src/sync/species-info/iucn.int.test.ts
```

The result.
```
D:/coding-projects/rfcx/biodiversity-analytics/apps/cli: pnpm exec cross-env BIO_DB_PORT=5434 vitest --no-threads src/sync/species-info/iucn.int.test.ts

 DEV  v0.13.1 D:/coding-projects/rfcx/biodiversity-analytics/apps/cli

stdout | unknown test
*** Biodiversity CLI ***
Running in default mode

stdout | src/sync/species-info/iucn.int.test.ts > rows created for 2 matching species
| syncOnlyMissingIUCNSpeciesInfo = 13

stdout | src/sync/species-info/iucn.int.test.ts > rows created for 2 matching species
- writeIucnSpeciesDataToPostgres: bulk upsert 13 species

stdout | src/sync/species-info/iucn.int.test.ts > rows created for non-matching species
| syncOnlyMissingIUCNSpeciesInfo = 4

stdout | src/sync/species-info/iucn.int.test.ts > rows created for non-matching species
- writeIucnSpeciesDataToPostgres: bulk upsert 4 species

stdout | src/sync/species-info/iucn.int.test.ts > risk rating updated after 1 month
| syncOnlyMissingIUCNSpeciesInfo = 4

stdout | src/sync/species-info/iucn.int.test.ts > risk rating updated after 1 month
- writeIucnSpeciesDataToPostgres: bulk upsert 4 species

stdout | src/sync/species-info/iucn.int.test.ts > risk rating updated after 1 month
| syncOnlyMissingIUCNSpeciesInfo = 1

stdout | src/sync/species-info/iucn.int.test.ts > risk rating updated after 1 month
- writeIucnSpeciesDataToPostgres: bulk upsert 1 species

stdout | src/sync/species-info/iucn.int.test.ts > risk rating not updated when IUCN data not found
| syncOnlyMissingIUCNSpeciesInfo = 4

stdout | src/sync/species-info/iucn.int.test.ts > risk rating not updated when IUCN data not found
- writeIucnSpeciesDataToPostgres: bulk upsert 4 species

stdout | src/sync/species-info/iucn.int.test.ts > risk rating not updated when IUCN data not found
| syncOnlyMissingIUCNSpeciesInfo = 1

stdout | src/sync/species-info/iucn.int.test.ts > risk rating not updated when IUCN data not found
- writeIucnSpeciesDataToPostgres: bulk upsert 1 species

stdout | src/sync/species-info/iucn.int.test.ts > risk rating not updated when getting IUCN data is rejected
| syncOnlyMissingIUCNSpeciesInfo = 4

stdout | src/sync/species-info/iucn.int.test.ts > risk rating not updated when getting IUCN data is rejected
- writeIucnSpeciesDataToPostgres: bulk upsert 4 species

stdout | src/sync/species-info/iucn.int.test.ts > risk rating not updated when getting IUCN data is rejected
| syncOnlyMissingIUCNSpeciesInfo = 1

 √ src/sync/species-info/iucn.int.test.ts (5)

Test Files  1 passed (1)
     Tests  5 passed (5)
      Time  4.42s (in thread 252ms, 1753.42%)
```