### PR TITLE
Create new `GET /classifiers` API

### DIFF
--- a/apps/api/src/_services/api-core/__mocks__/api-core.ts
+++ b/apps/api/src/_services/api-core/__mocks__/api-core.ts
@@ -1,5 +1,7 @@
 import { vi } from 'vitest'
 
+import { type Classifier } from '@rfcx-bio/common/api-bio/classifiers/classifiers'
+
 import { type CoreClassifierJob, type CoreClassifierJobClassificationSummary, type CoreClassifierJobInformation, type CoreClassifierJobTotalDetections, type CoreDetection } from '../types'
 
 const randomCoreId = (): string => (Math.random() + 1).toString(36).substring(6)
@@ -142,6 +144,36 @@ export const getDetections = vi.fn(async (): Promise<CoreDetection[]> => {
       classifier_id: 19,
       confidence: 0.984947475,
       review_status: 1
+    }
+  ]
+})
+
+export const getClassifiers = vi.fn(async (): Promise<Classifier[]> => {
+  return [
+    {
+      id: 1,
+      name: 'asia-elephant-edge',
+      version: 5
+    },
+    {
+      id: 2,
+      name: 'asia-elephant-edge',
+      version: 4
+    },
+    {
+      id: 3,
+      name: 'gunshot',
+      version: 1
+    },
+    {
+      id: 4,
+      name: 'pr-parrot',
+      version: 2
+    },
+    {
+      id: 5,
+      name: 'pr-parrot',
+      version: 1
     }
   ]
 })

--- a/apps/api/src/_services/api-core/api-core.ts
+++ b/apps/api/src/_services/api-core/api-core.ts
@@ -2,6 +2,7 @@ import axios from 'axios'
 import { type FastifyLoggerInstance } from 'fastify'
 
 import { type ClassifierQueryParams, type ClassifierResponse } from '@rfcx-bio/common/api-bio/classifiers/classifier'
+import { type Classifier } from '@rfcx-bio/common/api-bio/classifiers/classifiers'
 import { type DetectSummaryQueryParams, type DetectSummaryResponse } from '@rfcx-bio/common/api-bio/detect/detect-summary'
 import { type DetectValidationResultsQueryParams, type DetectValidationResultsResponse } from '@rfcx-bio/common/api-bio/detect/detect-validation-results'
 import { type DetectReviewDetectionBody, type DetectReviewDetectionResponse } from '@rfcx-bio/common/api-bio/detect/review-detections'
@@ -18,7 +19,7 @@ import {
   type CoreClassifierJobInformation,
   type CoreClassifierJobTotalDetections,
   type CoreDetection,
-  type CoreGetDetectionsQueryParams,
+    type CoreGetClassifiersQueryParams, type CoreGetDetectionsQueryParams,
   type DetectDetectionsQueryParamsCore,
   type DetectDetectionsResponseCore,
   type GetClassifierJobClassificationSummaryQueryParams
@@ -271,6 +272,30 @@ export async function getClassifierJobResultsFromApi (token: string, jobId: numb
         authorization: token
       },
       params: query
+    })
+
+    return resp.data
+  } catch (e) {
+    return unpackAxiosError(e)
+  }
+}
+
+export async function getClassifiers (token: string, params: CoreGetClassifiersQueryParams): Promise<Classifier[]> {
+  try {
+    const resp = await axios.request({
+      method: 'GET',
+      url: `${CORE_API_BASE_URL}/classifiers`,
+      params: {
+        ...params,
+        fields: [
+          'id',
+          'name',
+          'version'
+        ]
+      },
+      headers: {
+        authorization: token
+      }
     })
 
     return resp.data

--- a/apps/api/src/_services/api-core/types.ts
+++ b/apps/api/src/_services/api-core/types.ts
@@ -117,3 +117,10 @@ export interface CoreDetection {
   confidence: number
   review_status: CoreRawReviewStatus
 }
+
+export interface CoreGetClassifiersQueryParams {
+  limit?: number
+  offset?: number
+  sort?: string
+  fields?: string[]
+}

--- a/apps/api/src/classifiers/get-classifiers-bll.ts
+++ b/apps/api/src/classifiers/get-classifiers-bll.ts
@@ -1,0 +1,16 @@
+import { type Classifier, type GetClassifiersQueryParams } from '@rfcx-bio/common/api-bio/classifiers/classifiers'
+
+import { parseLimitOffset } from '@/search/helpers'
+import { getClassifiers as coreGetClassifiers } from '~/api-core/api-core'
+
+export const getClassifiers = async (token: string, params: GetClassifiersQueryParams): Promise<Classifier[]> => {
+  const { limit, offset } = parseLimitOffset(params.limit, params.offset, {
+    defaultLimit: 100
+  })
+
+  return await coreGetClassifiers(token, {
+    limit,
+    offset,
+    sort: params.sort === undefined || params.sort === '' ? undefined : params.sort
+  })
+}

--- a/apps/api/src/classifiers/get-classifiers-handler.int.test.ts
+++ b/apps/api/src/classifiers/get-classifiers-handler.int.test.ts
@@ -1,0 +1,102 @@
+import { describe, expect, test, vi } from 'vitest'
+
+import { makeApp } from '@rfcx-bio/testing/handlers'
+
+import * as core from '../_services/api-core/api-core'
+import { routesClassifiers } from './index'
+
+describe('GET /classifiers', async () => {
+  test('get the data successfully', async () => {
+    // Arrange
+    const app = await makeApp(routesClassifiers)
+
+    // Act
+    const response = await app.inject({
+      method: 'GET',
+      url: '/classifiers',
+      query: {
+        sort: 'name,-version',
+        limit: '5',
+        offset: '0'
+      }
+    })
+
+    expect(response.statusCode).toEqual(200)
+    const json = response.json()
+    expect(json).toHaveProperty('[0].id', 1)
+    expect(json).toHaveProperty('[0].name', 'asia-elephant-edge')
+    expect(json).toHaveProperty('[0].version', 5)
+    expect(json).toHaveProperty('[1].id', 2)
+    expect(json).toHaveProperty('[1].name', 'asia-elephant-edge')
+    expect(json).toHaveProperty('[1].version', 4)
+  })
+
+  test('undefined sort params is set to undefined', async () => {
+    // Arrange
+    const spy = vi.spyOn(core, 'getClassifiers')
+    const app = await makeApp(routesClassifiers)
+
+    // Act
+    const response = await app.inject({
+      method: 'GET',
+      url: '/classifiers',
+      query: {
+        limit: '5',
+        offset: '0'
+      }
+    })
+
+    expect(response.statusCode).toEqual(200)
+    expect(spy).toHaveBeenCalledWith('', {
+      sort: undefined,
+      limit: 5,
+      offset: 0
+    })
+  })
+
+  test('empty string sort params is set to undefined', async () => {
+    // Arrange
+    const spy = vi.spyOn(core, 'getClassifiers')
+    const app = await makeApp(routesClassifiers)
+
+    // Act
+    const response = await app.inject({
+      method: 'GET',
+      url: '/classifiers',
+      query: {
+        sort: '',
+        limit: '5',
+        offset: '0'
+      }
+    })
+
+    expect(response.statusCode).toEqual(200)
+    expect(spy).toHaveBeenCalledWith('', {
+      sort: undefined,
+      limit: 5,
+      offset: 0
+    })
+  })
+
+  test('missing limit and offset will be set', async () => {
+    // Arrange
+    const spy = vi.spyOn(core, 'getClassifiers')
+    const app = await makeApp(routesClassifiers)
+
+    // Act
+    const response = await app.inject({
+      method: 'GET',
+      url: '/classifiers',
+      query: {
+        sort: ''
+      }
+    })
+
+    expect(response.statusCode).toEqual(200)
+    expect(spy).toHaveBeenCalledWith('', {
+      sort: undefined,
+      limit: 100,
+      offset: 0
+    })
+  })
+})

--- a/apps/api/src/classifiers/get-classifiers-handler.ts
+++ b/apps/api/src/classifiers/get-classifiers-handler.ts
@@ -1,0 +1,8 @@
+import { type GetClassifiersQueryParams, type GetClassifiersResponse } from '@rfcx-bio/common/api-bio/classifiers/classifiers'
+
+import { type Handler } from '~/api-helpers/types'
+import { getClassifiers } from './get-classifiers-bll'
+
+export const getClassifiersHandler: Handler<GetClassifiersResponse, unknown, GetClassifiersQueryParams> = async (req, rep) => {
+  return await getClassifiers(req.headers?.authorization ?? '', req.query)
+}

--- a/apps/api/src/classifiers/index.ts
+++ b/apps/api/src/classifiers/index.ts
@@ -1,12 +1,19 @@
 import { classifierRoute } from '@rfcx-bio/common/api-bio/classifiers/classifier'
+import { getClassifiersRoute } from '@rfcx-bio/common/api-bio/classifiers/classifiers'
 
 import { type RouteRegistration, GET } from '~/api-helpers/types'
 import { classifierHandler } from './classifier-handler'
+import { getClassifiersHandler } from './get-classifiers-handler'
 
 export const routesClassifiers: RouteRegistration[] = [
   {
     method: GET,
     url: classifierRoute,
     handler: classifierHandler
+  },
+  {
+    method: GET,
+    url: getClassifiersRoute,
+    handler: getClassifiersHandler
   }
 ]

--- a/packages/common/src/api-bio/classifiers/classifiers.ts
+++ b/packages/common/src/api-bio/classifiers/classifiers.ts
@@ -1,0 +1,33 @@
+import { type AxiosInstance } from 'axios'
+
+// Request types
+export interface GetClassifiersQueryParams {
+  limit?: number
+  offset?: number
+  /**
+   * A sort string in the format of comma-separated string with optional negative sign `-`
+   * in the front to denote sorting descendingly by that column.
+   *
+   * The default sorting being `name,-version`. Meaning sort by `name` ascendingly,
+   * then sort by `version` descendingly.
+   */
+  sort?: string
+}
+
+// Response types
+export interface Classifier {
+  id: number
+  name: string
+  version: number
+}
+
+export type GetClassifiersResponse = Classifier[]
+
+// Route
+export const getClassifiersRoute = '/classifiers'
+
+// Service
+export const apiBioGetClassifiers = async (apiClient: AxiosInstance, params: GetClassifiersQueryParams): Promise<GetClassifiersResponse> => {
+  const response = await apiClient.get('/classifiers', { params })
+  return response.data
+}

--- a/packages/common/src/api-core/classifier/classifier-all.ts
+++ b/packages/common/src/api-core/classifier/classifier-all.ts
@@ -11,6 +11,9 @@ export interface ClassifierAllParams {
 // Response types
 export type ClassifierAllResponse = Classifier[]
 
+/**
+ * @deprecated core callings from the frontend will be moved to call by arbimon's backend
+ */
 export interface Classifier {
   id: number
   name: string
@@ -19,5 +22,8 @@ export interface Classifier {
 }
 
 // Service
+/**
+ * @deprecated please use `apiBioGetClassifiers`
+ */
 export const apiCoreGetClassifierAll = async (apiClient: AxiosInstance, params: ClassifierAllParams = {}): Promise<ClassifierAllResponse | undefined> =>
   await apiGetOrUndefined(apiClient, '/classifiers', { params })


### PR DESCRIPTION
### Description

Previously the `GET /classifiers` endpoint is being calld to core directly from the frontend. To proxy the core calls from the frontend we will call `GET /classifiers` to arbimon API first. Hence the task.

This API accepts optional query parameters of 
- `sort`. A sort string of column names and maybe a negative sign in the front to depicts that you want that column being sort ascendingly e.g. `name,-version` (default sort if none is given).
- `limit` and `offset`. default limit is `100`.

The return type of API is `Array<{ id: number, name: string, version: number }>`