### PR TITLE
feat(roles): display 'Primary Admin' for Owner role (display-only)

### DIFF
--- a/apps/api/src/dashboard/dashboard-stakeholders-dao.ts
+++ b/apps/api/src/dashboard/dashboard-stakeholders-dao.ts
@@ -1,6 +1,7 @@
 import { Op, QueryTypes } from 'sequelize'
 
 import { type DashboardStakeholdersUser } from '@rfcx-bio/common/api-bio/dashboard/dashboard-stakeholders'
+import { getRoleById, getRoleDisplayName } from '@rfcx-bio/common/roles'
 import { ModelRepository } from '@rfcx-bio/node-common/dao/model-repository'
 import { type LocationProjectUserRole, type OrganizationTypes } from '@rfcx-bio/node-common/dao/types'
 
@@ -35,6 +36,7 @@ export const getProjectUsers = async (projectId: number, onlyListedMembers: bool
   }
 
   return projectUsers.map(p => {
+    const role = getRoleById(p.roleId)
     return {
       id: p.id,
       email: p.email,
@@ -42,7 +44,9 @@ export const getProjectUsers = async (projectId: number, onlyListedMembers: bool
       lastName: p.lastName,
       image: fileUrl(p.image),
       roleId: p.roleId,
-      ranking: p.ranking
+      ranking: p.ranking,
+      role,
+      roleDisplayName: getRoleDisplayName(role)
     }
   })
 }
@@ -99,6 +103,7 @@ export const getProjectStakeholderUsers = async (projectId: number): Promise<Das
   })
   return users.map(u => {
     const p = profile.find(p => p.id === u.userId)
+    const role = getRoleById(u.roleId)
     return {
       id: u.userId,
       email: u.ranking !== 0 ? '' : p?.email ?? '', // only return email for primary contact
@@ -106,7 +111,9 @@ export const getProjectStakeholderUsers = async (projectId: number): Promise<Das
       lastName: p?.lastName ?? '',
       image: fileUrl(p?.image),
       roleId: u.roleId,
-      ranking: u.ranking
+      ranking: u.ranking,
+      role,
+      roleDisplayName: getRoleDisplayName(role)
     }
   })
 }

--- a/apps/api/src/projects/dao/project-member-dao.ts
+++ b/apps/api/src/projects/dao/project-member-dao.ts
@@ -1,6 +1,6 @@
 import { QueryTypes } from 'sequelize'
 
-import { type ProjectRole, getIdByRole, getRoleById } from '@rfcx-bio/common/roles'
+import { type ProjectRole, getIdByRole, getRoleById, getRoleDisplayName } from '@rfcx-bio/common/roles'
 import { ModelRepository } from '@rfcx-bio/node-common/dao/model-repository'
 import { type LocationProjectUserRole, type UserProfile } from '@rfcx-bio/node-common/dao/types'
 
@@ -11,7 +11,12 @@ import { getProjectById } from './projects-dao'
 const sequelize = getSequelize()
 const { LocationProjectUserRole: LocationProjectUserRoleModel } = ModelRepository.getInstance(sequelize)
 
-export const get = async (locationProjectId: number): Promise<Array<Omit<LocationProjectUserRole, 'createdAt' | 'updatedAt' | 'ranking'> & Pick<UserProfile, 'email' | 'firstName' | 'lastName' | 'image'>>> => {
+export type ProjectMemberRow =
+  Omit<LocationProjectUserRole, 'createdAt' | 'updatedAt' | 'ranking'>
+  & Pick<UserProfile, 'email' | 'firstName' | 'lastName' | 'image'>
+  & { role: ProjectRole, roleDisplayName: string }
+
+export const get = async (locationProjectId: number): Promise<ProjectMemberRow[]> => {
   const sql = `
     select
       location_project_user_role.location_project_id as "locationProjectId",
@@ -29,6 +34,7 @@ export const get = async (locationProjectId: number): Promise<Array<Omit<Locatio
   const users = await sequelize.query<Omit<LocationProjectUserRole, 'createdAt' | 'updatedAt' | 'ranking'> & Pick<UserProfile, 'email' | 'firstName' | 'lastName' | 'image'>>(sql, { bind: [locationProjectId], type: QueryTypes.SELECT })
 
   return users.map(u => {
+    const role = getRoleById(u.roleId)
     return {
       locationProjectId: u.locationProjectId,
       userId: u.userId,
@@ -36,7 +42,9 @@ export const get = async (locationProjectId: number): Promise<Array<Omit<Locatio
       lastName: u.lastName,
       image: fileUrl(u.image) ?? '',
       email: u.email,
-      roleId: u.roleId
+      roleId: u.roleId,
+      role,
+      roleDisplayName: getRoleDisplayName(role)
     }
   })
 }

--- a/apps/website/src/projects/project-member-page.vue
+++ b/apps/website/src/projects/project-member-page.vue
@@ -208,7 +208,7 @@
                 class="relative overflow-hidden mb-[-1px] text-center cursor-pointer py-3 hover:text-frequency"
                 @click="activeTab = 'owner'"
               >
-                Owner
+                Primary Admin
               </div>
               <div
                 :class="[activeTab === 'admin' ? 'font-medium text-frequency border-b-2 border-frequency bg-echo rounded-t-md' : '']"
@@ -364,8 +364,8 @@ const userToAdd = ref({
 const roles = [
   {
     id: 4,
-    name: 'Owner',
-    description: 'Project Owner - can manage and delete the project, edit project settings, and manage project members'
+    name: 'Primary Admin',
+    description: 'Project Primary Admin - can manage and delete the project, edit project settings, and manage project members'
   },
   {
     id: 1,

--- a/apps/website/src/projects/user-roles.vue
+++ b/apps/website/src/projects/user-roles.vue
@@ -131,7 +131,7 @@ interface Role {
 }
 
 const roles: Record<string, Role> = {
-  owner: { id: 'owner', name: 'Owner', description: 'Full access to project settings.' },
+  owner: { id: 'owner', name: 'Primary Admin', description: 'Full access to project settings.' },
   admin: { id: 'admin', name: 'Admin', description: 'Full access to project settings except deleting the project.' },
   expert: { id: 'expert', name: 'Expert', description: 'Manage sites, species, recordings, playlists, jobs, and validations' },
   user: { id: 'user', name: 'User', description: 'Manages sites, species, recordings, and playlists.' },

--- a/apps/website/src/super/member/components/member-item.vue
+++ b/apps/website/src/super/member/components/member-item.vue
@@ -12,7 +12,7 @@
       class="flex flex-start flex-row items-center gap-2 justify-start"
     >
       <p v-if="selectedRoleId === getIdByRole('owner')">
-        Owner
+        Primary Admin
       </p>
       <select
         v-else

--- a/apps/website/src/super/project/components/project-tiering-table.vue
+++ b/apps/website/src/super/project/components/project-tiering-table.vue
@@ -194,7 +194,7 @@ const toggleProjectLock = async (project: SuperProjectSummary): Promise<void> =>
 }
 
 const getRoleLabel = (roleId: number): string => {
-  if (roleId === 4) return 'Owner'
+  if (roleId === 4) return 'Primary Admin'
   if (roleId === 3) return 'Guest'
   if (roleId === 2) return 'Admin'
   return 'Collaborator'

--- a/packages/common/src/api-bio/dashboard/dashboard-stakeholders.ts
+++ b/packages/common/src/api-bio/dashboard/dashboard-stakeholders.ts
@@ -1,6 +1,7 @@
 import { type AxiosInstance } from 'axios'
 
 import { type LocationProjectUserRole, type OrganizationTypes, type UserProfile } from '../../dao/types'
+import { type ProjectRole } from '../../roles'
 import { type ProjectRouteParamsSerialized, PROJECT_SPECIFIC_ROUTE_PREFIX } from '../_helpers'
 
 // The `GET` Service
@@ -9,7 +10,15 @@ import { type ProjectRouteParamsSerialized, PROJECT_SPECIFIC_ROUTE_PREFIX } from
 export type DashboardStakeholdersParams = ProjectRouteParamsSerialized
 
 // Response types
-export type DashboardStakeholdersUser = Pick<UserProfile, 'email' | 'firstName' | 'lastName' | 'id' | 'image'> & Pick<LocationProjectUserRole, 'roleId' | 'ranking'>
+export type DashboardStakeholdersUser =
+  Pick<UserProfile, 'email' | 'firstName' | 'lastName' | 'id' | 'image'>
+  & Pick<LocationProjectUserRole, 'roleId' | 'ranking'>
+  & {
+    /** Internal role identifier (unchanged), e.g. 'owner'. */
+    role?: ProjectRole
+    /** Display-only label, e.g. 'Primary Admin' for owner. */
+    roleDisplayName?: string
+  }
 export interface DashboardStakeholdersResponse {
   users: DashboardStakeholdersUser[]
   organizations: Array<OrganizationTypes['light']>

--- a/packages/common/src/api-bio/project/project-members.ts
+++ b/packages/common/src/api-bio/project/project-members.ts
@@ -8,7 +8,15 @@ import { type ProjectRouteParamsSerialized, PROJECT_SPECIFIC_ROUTE_PREFIX } from
 export type ProjectMembersParams = ProjectRouteParamsSerialized
 
 // Response type
-export type ProjectMember = Omit<LocationProjectUserRole, 'createdAt' | 'updatedAt' | 'ranking'> & Pick<UserProfile, 'email' | 'firstName' | 'lastName' | 'image'>
+export type ProjectMember =
+  Omit<LocationProjectUserRole, 'createdAt' | 'updatedAt' | 'ranking'>
+  & Pick<UserProfile, 'email' | 'firstName' | 'lastName' | 'image'>
+  & {
+    /** Internal role identifier (unchanged), e.g. 'owner' | 'admin' | ... */
+    role?: ProjectRole
+    /** Display-only label, e.g. 'Primary Admin' for owner. Does not affect logic. */
+    roleDisplayName?: string
+  }
 export type ProjectMembersResponse = ProjectMember[]
 
 export interface ProjectMemberAddRemoveRequest {

--- a/packages/common/src/roles/index.ts
+++ b/packages/common/src/roles/index.ts
@@ -12,6 +12,28 @@ const roles: Record<number, ProjectRole> = {
 
 export const orderedRoles: ProjectRole[] = ['external', 'viewer', 'entry', 'user', 'expert', 'admin', 'owner']
 
+/**
+ * Display-only mapping for ProjectRole names.
+ *
+ * IMPORTANT: This is for UI/serialization labels ONLY. The internal `ProjectRole`
+ * values (e.g. 'owner') and database role ids (e.g. 4) are unchanged. Code paths
+ * that compare role identifiers must continue to use the `ProjectRole` value
+ * (e.g. `role === 'owner'`), not the display name.
+ */
+const roleDisplayNames: Record<ProjectRole, string> = {
+  none: 'None',
+  external: 'External',
+  viewer: 'Guest',
+  entry: 'Data Entry',
+  user: 'User',
+  expert: 'Expert',
+  admin: 'Admin',
+  owner: 'Primary Admin'
+}
+
+export const getRoleDisplayName = (role: ProjectRole): string => roleDisplayNames[role] ?? 'None'
+export const getRoleDisplayNameById = (roleId: number): string => getRoleDisplayName(getRoleById(roleId))
+
 export const rolesGreaterOrEqualTo = (role: ProjectRole): ProjectRole[] =>
   orderedRoles.filter((r, i) => i >= orderedRoles.indexOf(role))
 

--- a/packages/common/src/roles/index.unit.test.ts
+++ b/packages/common/src/roles/index.unit.test.ts
@@ -1,6 +1,6 @@
 import { expect, test } from 'vitest'
 
-import { getIdByRole, rolesGreaterOrEqualTo } from './index'
+import { getIdByRole, getRoleDisplayName, getRoleDisplayNameById, rolesGreaterOrEqualTo } from './index'
 
 test('rolesGreaterOrEqualTo returns roles', () => {
   expect(rolesGreaterOrEqualTo('external')).toEqual(['external', 'viewer', 'entry', 'user', 'expert', 'admin', 'owner'])
@@ -13,4 +13,25 @@ test('getIdByRole returns roles', () => {
   expect(getIdByRole('user')).toBe(2)
   expect(getIdByRole('owner')).toBe(4)
   expect(typeof getIdByRole('owner')).toBe('number')
+})
+
+test('getRoleDisplayName maps owner to "Primary Admin" but keeps internal role unchanged', () => {
+  expect(getRoleDisplayName('owner')).toBe('Primary Admin')
+  expect(getRoleDisplayName('admin')).toBe('Admin')
+  expect(getRoleDisplayName('expert')).toBe('Expert')
+  expect(getRoleDisplayName('user')).toBe('User')
+  expect(getRoleDisplayName('entry')).toBe('Data Entry')
+  expect(getRoleDisplayName('viewer')).toBe('Guest')
+  expect(getRoleDisplayName('external')).toBe('External')
+  expect(getRoleDisplayName('none')).toBe('None')
+})
+
+test('getRoleDisplayNameById uses owner role id 4 to display "Primary Admin"', () => {
+  expect(getRoleDisplayNameById(4)).toBe('Primary Admin')
+  expect(getRoleDisplayNameById(1)).toBe('Admin')
+  expect(getRoleDisplayNameById(2)).toBe('User')
+  expect(getRoleDisplayNameById(3)).toBe('Guest')
+  expect(getRoleDisplayNameById(5)).toBe('Data Entry')
+  expect(getRoleDisplayNameById(6)).toBe('Expert')
+  expect(getRoleDisplayNameById(999)).toBe('None')
 })


### PR DESCRIPTION
## Summary

Display-only rename of the **Owner** project role to **Primary Admin**. Internal `ProjectRole` value (`'owner'`) and DB `role_id=4` are unchanged. Permissions and role checks continue to use the canonical `'owner'` value.

## Changes

**Shared mapper** (`packages/common/src/roles/index.ts`)
- Add `getRoleDisplayName(role)` and `getRoleDisplayNameById(roleId)` exporting friendly labels (`owner -> 'Primary Admin'`, others passthrough).

**Bio API serializers**
- `apps/api/src/projects/dao/project-member-dao.ts` and `apps/api/src/dashboard/dashboard-stakeholders-dao.ts` now include `roleDisplayName` alongside the existing `roleId` in member/stakeholder responses.
- Response types in `packages/common/src/api-bio/project/project-members.ts` and `.../dashboard/dashboard-stakeholders.ts` add the optional `roleDisplayName` field.

**Modern UI labels (display-only)**
- `apps/website/src/projects/project-member-page.vue` — Owner tab label and role description.
- `apps/website/src/projects/user-roles.vue` — role card name.
- `apps/website/src/super/member/components/member-item.vue` — header label.
- `apps/website/src/super/project/components/project-tiering-table.vue` — column label.

**Tests**
- Extend `packages/common/src/roles/index.unit.test.ts` to cover display-name mapping.

## Non-changes (intentional)

- No DB migrations.
- `ProjectRole = 'owner'` and `role_id = 4` unchanged.
- All `role === 'owner'` / `getIdByRole('owner')` permission checks unchanged.
- Existing `role` and `roleId` fields preserved on all responses.

## Test commands

\`\`\`
pnpm --filter @rfcx-bio/common test:unit -- --run
pnpm -r test:unit -- --run
pnpm -r build
\`\`\`

Pairs with rfcx/rfcx-api#? (\`feat/role-display-primary-admin\`).