### PR TITLE
ci(cd): remove AWS build+deploy jobs (kops decommissioned)

### DIFF
--- a/.github/workflows/cd.yaml
+++ b/.github/workflows/cd.yaml
@@ -46,73 +46,6 @@ jobs:
           echo "release-date=$( date +"%s" ) >> $GITHUB_OUTPUT"
           echo "short-sha=$(echo ${GITHUB_SHA} | cut -c1-8) >> $GITHUB_OUTPUT"
 
-  build:
-    name: 'Build'
-    needs: [configure]
-    uses: rfcx/cicd/.github/workflows/ecr-build-push.yaml@master
-    with:
-      dockerfile: tools/deployment/Dockerfile
-      targets: "[\"biodiversity-api\",\"biodiversity-cli\",\"biodiversity-website\"]"
-      tag-environment: ${{ needs.configure.outputs.namespace }}
-      tag-latest: ${{ needs.configure.outputs.namespace == 'production' }}
-      build-args: |            
-        mode=${{ needs.configure.outputs.namespace }}
-        release_commit=${{ needs.configure.outputs.short-sha }}
-        release_date=${{ needs.configure.outputs.release-date }}
-    secrets:
-      aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-      aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-
-  deploy:
-    name: 'Deploy'
-    runs-on: deployment-runner
-    needs: ['build', 'configure']
-    steps:
-      - name: 'Deploy: Setup Git checkout'
-        # v4 (4.1.1) @ 17 Oct 2023 https://github.com/actions/checkout/tags
-        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11
-
-      - name: 'Deploy: Set image version'
-        run: |
-          find tools/deployment -name "*.yaml" -exec sed -i s/:latest/:${{ needs.build.outputs.unique-tag }}/g {} +
-          find tools/deployment -name "*.yaml" -exec sed -i s/JOB_NUMBER/${{ github.run_number }}/g {} +
-
-      - name: 'Deploy: Kubernetes apply CLI (starts migrate)'
-        if: ${{ github.event_name != 'workflow_dispatch' || inputs.deploy_cli }}
-        # v1 (1.28.2) @ 19 Oct 2023 https://github.com/actions-hub/kubectl/tags
-        uses: actions-hub/kubectl@2d1ce94ead5b3ba03de25df993a359c1b4657b05
-        env:
-          KUBE_CONFIG: ${{ secrets.KUBE_CONFIG_SUPER }}
-        with:
-          args: apply -f ./tools/deployment/cli/${{ needs.configure.outputs.namespace }}
-
-      - name: 'Deploy: Wait for migrate to complete successfully'
-        if: ${{ github.event_name != 'workflow_dispatch' || inputs.deploy_cli }}
-        # v1 (1.28.2) @ 19 Oct 2023 https://github.com/actions-hub/kubectl/tags
-        uses: actions-hub/kubectl@2d1ce94ead5b3ba03de25df993a359c1b4657b05
-        env:
-          KUBE_CONFIG: ${{ secrets.KUBE_CONFIG_SUPER }}
-        with:
-          args: wait --for=condition=complete --timeout=500s -n ${{ needs.configure.outputs.namespace }} job/biodiversity-cli-migrate-${{ github.run_number }}
-
-      - name: 'Deploy: Kubernetes apply API'
-        if: ${{ github.event_name != 'workflow_dispatch' || inputs.deploy_api }}
-        # v1 (1.28.2) @ 19 Oct 2023 https://github.com/actions-hub/kubectl/tags
-        uses: actions-hub/kubectl@2d1ce94ead5b3ba03de25df993a359c1b4657b05
-        env:
-          KUBE_CONFIG: ${{ secrets.KUBE_CONFIG_SUPER }}
-        with:
-          args: apply -f ./tools/deployment/api/${{ needs.configure.outputs.namespace }}
-
-      - name: 'Deploy: Kubernetes apply WEB'
-        if: ${{ github.event_name != 'workflow_dispatch' || inputs.deploy_web }}
-        # v1 (1.28.2) @ 19 Oct 2023 https://github.com/actions-hub/kubectl/tags
-        uses: actions-hub/kubectl@2d1ce94ead5b3ba03de25df993a359c1b4657b05
-        env:
-          KUBE_CONFIG: ${{ secrets.KUBE_CONFIG_SUPER }}
-        with:
-          args: apply -f ./tools/deployment/website/${{ needs.configure.outputs.namespace }}
-
   deploy-rfcx-local:
     name: 'Deploy: rfcx-local'
     needs: [configure]
@@ -132,14 +65,14 @@ jobs:
   notify:
     name: 'Notify'
     if: ${{ always() }}
-    needs: [build, deploy, deploy-rfcx-local]
+    needs: [deploy-rfcx-local]
     uses: rfcx/cicd/.github/workflows/notify.yaml@master
     with:
       workflow-id: cd.yaml
-      status: ${{ needs.deploy.result }}
+      status: ${{ needs.deploy-rfcx-local.result }}
       always: true
       notification-title: 'CD: Arbimon'
-      notification-footer: "Build: ${{ needs.build.result || 'n/a' }} | Deploy: ${{ needs.deploy.result || 'n/a' }}"
+      notification-footer: "Deploy (rfcx-local): ${{ needs.deploy-rfcx-local.result || 'n/a' }}"
     secrets:
       slack-webhook: ${{ secrets.SLACK_ALERT_ARBIMON_WEBHOOK }}
       github-token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary

Removes the AWS-targeted `build:` (ECR push) and `deploy:` (kops kubectl apply) jobs from this repo's `cd.yaml`. The kops production cluster has been declared dead by the operator (2026-05-18 18:55 EDT), and rfcx-local is now the sole production deploy target.

## Why target `master` directly

For most rfcx-org repos in this sweep (`device-api`, `guardian-api`, `guardian-dashboard`, `rfcx-api`, `ingest-service`), `staging` is a per-cycle promotion branch created fresh from `master` and the PR targets `staging`. **For this repo, `staging` is an active dev branch with significant unmerged work** (143 commits ahead of master for `arbimon`, 54 for `arbimon-legacy`). Routing the AWS-strip through staging would conflict with all that unrelated dev work.

Two practical paths:
1. Land this PR directly to `master` (chosen). A separate PR can strip AWS from `staging`'s `cd.yaml` if/when the operator wants it.
2. Wait for the next big `staging → master` promotion and bundle the strip then. Rejected because that promotion's timing is unknown and AWS deploys keep retrying-and-failing in the meantime.

The next `staging → master` promotion in this repo will need to conflict-resolve `cd.yaml` (preserve master's stripped version). That's a one-time, narrow conflict and clearly mechanical.

## Background

- **Phase 3 (2026-05-18 18:55 EDT)** moved the device-upload data plane entirely off AWS — see `evity-squibbon/rfcx-local`'s `STATE.md` "Phase 3 Status" + "AWS / kops decommission status" blocks.
- All kops Mandrill keys revoked; staging/prediction/arbimon-jobs-staging namespaces deleted.
- The AWS `build:` and `deploy:` jobs in this workflow either fail noisily (most recent run on rfcx-api) or, once `KUBE_CONFIG_SUPER` rotates / kops gets torn down, will fail uniformly. They have no useful behaviour going forward.
- The `deploy-rfcx-local:` job (added 2026-05-16) does its own in-cluster arm64 build via the self-hosted runner in the rfcx-local cluster's `cicd` namespace, pushes to the in-cluster registry at `192.168.5.1:30500`, and rolls `apps-prod` Deployments via the runner's RBAC. It has zero dependency on the AWS jobs.

## What changes

In `.github/workflows/cd.yaml`:

- **Removed** `build:` job (uses `rfcx/cicd/.github/workflows/ecr-build-push.yaml@master`)
- **Removed** `deploy:` job (inline `actions-hub/kubectl@…` running `apply -f tools/deployment/...` against `KUBE_CONFIG_SUPER`)
- **Updated** `notify.needs:` to depend only on `[deploy-rfcx-local]`
- **Updated** notify `status` to report `deploy-rfcx-local.result`
- **Updated** notify `notification-footer` to surface only the rfcx-local result

`configure:` is kept (still needed for `deploy-rfcx-local`'s `if: namespace == 'production'` gate). Workflow_dispatch inputs (`deploy_cli`/`deploy_api`/`deploy_web` for arbimon) are left alone — they're harmless dead config now and removing them would expand the diff for no operational gain.

## What's unchanged

`deploy-rfcx-local:` is byte-identical. So is `concurrency:`. No new secrets, no required secrets newly absent (`KUBE_CONFIG_SUPER` / `AWS_*_KEY` are simply no longer referenced).

## Rollback

Revert this PR. The AWS jobs come back. Note: this only restores the workflow definition — kops production itself is dead regardless, so the AWS jobs will fail until kops comes back (which is not the plan).

## Related

- Companion PRs across the rfcx-org repo sweep: `rfcx/{rfcx-api#656, ingest-service#93, device-api#85, guardian-api#37, guardian-dashboard#219}` (these target `staging` since their staging is per-cycle).
- `evity-squibbon/rfcx-local` branch convention: `agent/ms4-strip-aws-cd-20260519`.