### PR TITLE
ci(cd): align staging cd.yaml with master (strip AWS)

### DIFF
--- a/.github/workflows/cd.yaml
+++ b/.github/workflows/cd.yaml
@@ -46,84 +46,33 @@ jobs:
           echo "release-date=$( date +"%s" ) >> $GITHUB_OUTPUT"
           echo "short-sha=$(echo ${GITHUB_SHA} | cut -c1-8) >> $GITHUB_OUTPUT"
 
-  build:
-    name: 'Build'
+  deploy-rfcx-local:
+    name: 'Deploy: rfcx-local'
     needs: [configure]
-    uses: rfcx/cicd/.github/workflows/ecr-build-push.yaml@master
+    if: ${{ needs.configure.outputs.namespace == 'production' }}
+    uses: rfcx/cicd/.github/workflows/rfcx-local-cd.yaml@master
     with:
+      repo: arbimon
       dockerfile: tools/deployment/Dockerfile
-      targets: "[\"biodiversity-api\",\"biodiversity-cli\",\"biodiversity-website\"]"
-      tag-environment: ${{ needs.configure.outputs.namespace }}
-      tag-latest: ${{ needs.configure.outputs.namespace == 'production' }}
-      build-args: |            
-        mode=${{ needs.configure.outputs.namespace }}
-        release_commit=${{ needs.configure.outputs.short-sha }}
-        release_date=${{ needs.configure.outputs.release-date }}
-    secrets:
-      aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-      aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+      targets: '["biodiversity-api","biodiversity-cli","biodiversity-website"]'
+      deployments: |
+        [
+          {"name": "biodiversity-api",     "image": "biodiversity-api"},
+          {"name": "biodiversity-website", "image": "biodiversity-website"}
+        ]
 
-  deploy:
-    name: 'Deploy'
-    runs-on: deployment-runner
-    needs: ['build', 'configure']
-    steps:
-      - name: 'Deploy: Setup Git checkout'
-        # v4 (4.1.1) @ 17 Oct 2023 https://github.com/actions/checkout/tags
-        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11
-
-      - name: 'Deploy: Set image version'
-        run: |
-          find tools/deployment -name "*.yaml" -exec sed -i s/:latest/:${{ needs.build.outputs.unique-tag }}/g {} +
-          find tools/deployment -name "*.yaml" -exec sed -i s/JOB_NUMBER/${{ github.run_number }}/g {} +
-
-      - name: 'Deploy: Kubernetes apply CLI (starts migrate)'
-        if: ${{ github.event_name != 'workflow_dispatch' || inputs.deploy_cli }}
-        # v1 (1.28.2) @ 19 Oct 2023 https://github.com/actions-hub/kubectl/tags
-        uses: actions-hub/kubectl@2d1ce94ead5b3ba03de25df993a359c1b4657b05
-        env:
-          KUBE_CONFIG: ${{ secrets.KUBE_CONFIG_SUPER }}
-        with:
-          args: apply -f ./tools/deployment/cli/${{ needs.configure.outputs.namespace }}
-
-      - name: 'Deploy: Wait for migrate to complete successfully'
-        if: ${{ github.event_name != 'workflow_dispatch' || inputs.deploy_cli }}
-        # v1 (1.28.2) @ 19 Oct 2023 https://github.com/actions-hub/kubectl/tags
-        uses: actions-hub/kubectl@2d1ce94ead5b3ba03de25df993a359c1b4657b05
-        env:
-          KUBE_CONFIG: ${{ secrets.KUBE_CONFIG_SUPER }}
-        with:
-          args: wait --for=condition=complete --timeout=500s -n ${{ needs.configure.outputs.namespace }} job/biodiversity-cli-migrate-${{ github.run_number }}
-
-      - name: 'Deploy: Kubernetes apply API'
-        if: ${{ github.event_name != 'workflow_dispatch' || inputs.deploy_api }}
-        # v1 (1.28.2) @ 19 Oct 2023 https://github.com/actions-hub/kubectl/tags
-        uses: actions-hub/kubectl@2d1ce94ead5b3ba03de25df993a359c1b4657b05
-        env:
-          KUBE_CONFIG: ${{ secrets.KUBE_CONFIG_SUPER }}
-        with:
-          args: apply -f ./tools/deployment/api/${{ needs.configure.outputs.namespace }}
-
-      - name: 'Deploy: Kubernetes apply WEB'
-        if: ${{ github.event_name != 'workflow_dispatch' || inputs.deploy_web }}
-        # v1 (1.28.2) @ 19 Oct 2023 https://github.com/actions-hub/kubectl/tags
-        uses: actions-hub/kubectl@2d1ce94ead5b3ba03de25df993a359c1b4657b05
-        env:
-          KUBE_CONFIG: ${{ secrets.KUBE_CONFIG_SUPER }}
-        with:
-          args: apply -f ./tools/deployment/website/${{ needs.configure.outputs.namespace }}
 
   notify:
     name: 'Notify'
     if: ${{ always() }}
-    needs: [build, deploy]
+    needs: [deploy-rfcx-local]
     uses: rfcx/cicd/.github/workflows/notify.yaml@master
     with:
       workflow-id: cd.yaml
-      status: ${{ needs.deploy.result }}
+      status: ${{ needs.deploy-rfcx-local.result }}
       always: true
       notification-title: 'CD: Arbimon'
-      notification-footer: "Build: ${{ needs.build.result || 'n/a' }} | Deploy: ${{ needs.deploy.result || 'n/a' }}"
+      notification-footer: "Deploy (rfcx-local): ${{ needs.deploy-rfcx-local.result || 'n/a' }}"
     secrets:
       slack-webhook: ${{ secrets.SLACK_ALERT_ARBIMON_WEBHOOK }}
       github-token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary

Aligns `staging` branch's `cd.yaml` with the post-strip `master` version. Avoids the conflict that would otherwise hit the next big `staging → master` promotion.

## Background

Earlier today (~02:13 EDT) the AWS `build:`/`deploy:` jobs were stripped from `master`'s `cd.yaml` in this repo as part of the kops-decommission sweep (kops production declared dead by operator 2026-05-18 18:55 EDT). For repos where `staging` is a per-cycle promotion branch (`rfcx-api`, `ingest-service`, `device-api`, `guardian-api`, `guardian-dashboard`), the strip went through `feat → staging → master` cleanly.

**For this repo, `staging` is an active dev branch** (diverged from master with significant unmerged work). So the strip targeted `master` directly there, leaving `staging` still carrying the AWS-only `cd.yaml`.

That leaves two problems:
1. Pushes to `staging` continue to try to run the AWS pipeline (will fail noisily once `KUBE_CONFIG_SUPER` rotates / kops is fully torn down).
2. The next big `staging → master` promotion will hit a one-file conflict on `cd.yaml`.

## What changes

Copies `cd.yaml` from `master` (post-strip) onto `staging`. That's the only file in the diff. Net effect:

- Pushes to `staging` run `prepare → configure → notify`, with `deploy-rfcx-local:` skipped (it's gated `if: namespace == 'production'`). Effectively a no-op-but-workflow-validates run on staging push.
- The `deploy-rfcx-local:` job is added to staging so it's the same shape as master. Doesn't actually fire on staging pushes (namespace gate), but is present and consistent.
- AWS jobs gone, AWS secrets no longer referenced.

## What this does NOT do

- Doesn't touch any other dev work on staging.
- Doesn't promote anything to master.
- Doesn't trigger a production deploy (CD on staging push is no-op-deploy).

## Validation

Generated `cd.yaml` is byte-identical to the version already running on `master` in this repo (which has been validated by the in-progress and recently-completed master CD runs). YAML parses (`python3 -c 'import yaml; yaml.safe_load(...)'`).

## Rollback

Revert this PR. Brings the AWS pipeline back on staging push (which will then start failing noisily again).

## Related

- Master strip PR for this repo (merged earlier today): see commit on `master`.
- Companion staging-strip PR in the sibling repo (`arbimon` ↔ `arbimon-legacy`).
- `evity-squibbon/rfcx-local`: `STATE.md` "AWS / kops decommission status", `runbooks/ACTIVE-SESSIONS.md`, `~/.evity/workspace/memory/2026-05-19-cd-wave-complete.md`.