### PR TITLE
fix(visualizer): make recording fetch fire reliably + clean up clustering URL

### DIFF
--- a/apps/website/src/insights/activity-patterns/components/species-selector/species-selector.vue
+++ b/apps/website/src/insights/activity-patterns/components/species-selector/species-selector.vue
@@ -160,7 +160,6 @@ watch(allSpecies, (newValue) => {
       selectedSpeciesSlug.value = allSpecies.value[0].taxonSpeciesSlug
     }
   }
-
 })
 
 watch(selectedSpeciesSlug, () => {

--- a/apps/website/src/projects/audiodata/_composables/use-visualizer.ts
+++ b/apps/website/src/projects/audiodata/_composables/use-visualizer.ts
@@ -5,12 +5,19 @@ import { type ComputedRef, computed } from 'vue'
 import { type AedResponse, type ClusterResponse, type CounSoundscapeCompositiontById, type newTemplateResponse, type NormVector, type PlaylistInfo, type RecordingPatternMatchingBoxesParams, type RecordingPatternMatchingBoxesResponse, type RecordingResponse, type RecordingSearchParams, type RecordingTagResponse, type RecordingValidateParams, type RecordingValidateResponse, type SoundscapeCompositionParams, type SoundscapeCompositionResponse, type SoundscapeItem, type SoundscapeItemOptions, type SoundscapeRegion, type SoundscapeResponse, type SoundscapeScidx, type TagDeleteResponse, type TagParams, type TemplateParams, type TemplateResponse, type VisobjectResponse, apiArbimonGetAed, apiArbimonGetClustering, apiArbimonGetPlaylistInfo, apiArbimonGetRecording, apiArbimonGetRecordings, apiDeleteRecordingTag, apiGetPatternMatchingBoxes, apiGetRecordingTag, apiGetSoundscapeComposition, apiGetSoundscapeNormVector, apiGetSoundscapeRegions, apiGetSoundscapes, apiGetSoundscapeScale, apiGetSoundscapeScidx, apiGetTemplates, apiPostSoundscapeComposition, apiPostTemplate, apiPutRecordingTag, apiRecordingValidate, apiSearchTag } from '@rfcx-bio/common/api-arbimon/audiodata/visualizer'
 
 export const useGetRecording = (apiClient: AxiosInstance, slug: ComputedRef<string | undefined>, recordingId: ComputedRef<string | undefined>): UseQueryReturnType<VisobjectResponse | undefined, unknown> => {
+  // Only fire the query when both keys are present. Vue Query watches `enabled`
+  // and auto-runs the query the moment the computed flips to true, which
+  // covers the common case where the recording id arrives a tick after mount.
+  // Without `enabled` the query is treated as always-on and may not refetch
+  // when the params settle, leaving the visualizer stuck without a recording.
+  const enabled = computed(() => Boolean(slug.value && recordingId.value))
   return useQuery({
     queryKey: ['fetch-recording', slug, recordingId],
     queryFn: async () => {
-      if (slug.value === undefined || recordingId.value === undefined || recordingId.value === '') return null
-      return await apiArbimonGetRecording(apiClient, slug.value, recordingId.value)
+      if (!enabled.value) return null
+      return await apiArbimonGetRecording(apiClient, slug.value as string, recordingId.value as string)
     },
+    enabled,
     retry: 0,
     refetchOnMount: false, // No refetch on page revisit
     refetchOnWindowFocus: false // No refetch on tab focus

--- a/apps/website/src/projects/project-settings-page.vue
+++ b/apps/website/src/projects/project-settings-page.vue
@@ -197,7 +197,6 @@ const date = Math.floor(Date.now() / 1000)
 const lastModified = ref<number>(date)
 const lastSaved = ref<number>(date)
 
-
 const isToggledForBackup = computed(() => {
   const isInternalUser = store.user?.email?.includes('rfcx.org') ?? false
   return toggles?.projectBackup === true || isInternalUser

--- a/packages/common/src/api-arbimon/audiodata/visualizer.ts
+++ b/packages/common/src/api-arbimon/audiodata/visualizer.ts
@@ -481,7 +481,13 @@ export const apiArbimonGetClustering = async (
 ): Promise<ClusterResponse | undefined> => {
   if (!slug || recId == null) return undefined
 
-  const url = `/legacy-api/project/${slug}/clustering-jobs/undefined/rois-details`
+  // The legacy route is `/clustering-jobs/:job_id/rois-details` but the handler
+  // reads everything from the POST body (rec_id, all, etc.) and ignores the
+  // `:job_id` URL segment. We pass `_` as a placeholder so the URL is well-formed
+  // and clearly intentional (the previous literal string `undefined` was a
+  // refactor leftover that looked like a bug in network traces and could break
+  // if the legacy route is ever cleaned up).
+  const url = `/legacy-api/project/${slug}/clustering-jobs/_/rois-details`
   const res = await apiClient.request<ClusterResponse>({
     method: 'POST',
     url,


### PR DESCRIPTION
## Summary

The visualizer page (`/p/<slug>/visualizer/rec/<id>`) was silently failing to fetch the recording on direct-URL navigation, leaving the spectrogram area showing 'Please select a recording' indefinitely. Backend was healthy — the front-end simply never made the `/legacy-api/project/<slug>/recordings/info/<id>` request.

## Root cause

`useGetRecording` in `apps/website/src/projects/audiodata/_composables/use-visualizer.ts` was missing the `enabled` flag on its `useQuery` config. Compare with `useGetClustering` four functions below — that one correctly uses an `enabled` computed and works as expected. Without `enabled`, when `slug` or `recordingId` resolves a tick after mount (the normal case for direct URL hits), the query can stay in an unfired state.

## Commits

1. **`fix(visualizer): ...`** — the actual fix.
   - `apps/website/src/projects/audiodata/_composables/use-visualizer.ts` — add `enabled = computed(() => Boolean(slug.value && recordingId.value))` and pass it to `useQuery`. Vue Query auto-runs the query the moment the computed flips to true.
   - `packages/common/src/api-arbimon/audiodata/visualizer.ts` — drive-by cleanup: `apiArbimonGetClustering` was interpolating the literal string `undefined` into the URL (`/clustering-jobs/undefined/rois-details`). Replaced with `_` placeholder + comment.

2. **`chore(lint): remove stray blank lines from develop`** — required to make CI pass. Two pre-existing lint errors on develop, introduced during recent `master -> develop` reconciliation merges (PRs #2453 / #2455), have been failing every CI On Push build since 2026-05-19 08:37 ET. Trivial whitespace fixes in two files (`species-selector.vue`, `project-settings-page.vue`). Verified locally with `pnpm run lint:eslint` — 0 errors after fix.

## How this was found

Live debugging from a separate Mac over the LAN, using the standalone-browser framework's authenticated remote-CDP proxy + network capture. Network trace from a stuck visualizer page on `biosoundscape/rec/155090002` showed every sidebar API call returning 200, but no `/recordings/info/` request was ever fired. Reading `useGetRecording` against the working pattern in `useGetClustering` immediately surfaced the missing `enabled` flag.

## Test plan

- [x] Diff reviewed (small, surgical)
- [x] Local `pnpm run lint:eslint` passes with 0 errors after the lint cleanup
- [x] Local `pnpm run lint:stylelint` passes
- [x] Matches existing pattern in sibling function `useGetClustering`
- [ ] CI build passes (this PR — currently re-running)
- [ ] Verify locally on `develop`: load `/p/biosoundscape/visualizer/rec/155090002` and confirm spectrogram renders
- [ ] Verify in staging after promotion
- [ ] Verify in production after promotion