### PR TITLE
ci(cd): drop no-op 'staging' push trigger

### DIFF
--- a/.github/workflows/cd.yaml
+++ b/.github/workflows/cd.yaml
@@ -17,7 +17,13 @@ on:
   push:
     branches:
       - master
-      - staging
+      # NOTE: 'staging' was removed from this list 2026-05-19. The current
+      # `Deploy: rfcx-local` job is gated to namespace=='production' (master
+      # only), so push to staging triggered the workflow but skipped every
+      # deploy step. Until a real staging environment is provisioned in
+      # rfcx-local (apps-staging namespace + staging.arbimon.org ingress),
+      # CD on staging is a no-op and only confused contributors. See
+      # rfcx-local STATE.md / runbooks for the planned staging environment.
 concurrency: ${{ github.workflow }}-${{ github.ref }}
 jobs:  
   configure:


### PR DESCRIPTION
## Problem

The current `Deploy: rfcx-local` job in `cd.yaml` is gated to `namespace == 'production'` (master branch only) — see lines around 'if: needs.configure.outputs.namespace == production'. Pushing to staging triggers the CD workflow but every deploy step is skipped. This:

- wastes CI minutes,
- emits misleading 'CD ran successfully' Slack notifications,
- confuses agents/contributors into thinking they're deploying to a staging environment that doesn't currently exist (kops decommission left no staging cluster behind).

I just hit this myself while promoting PR #2457 through develop → staging → master: the staging promotion looked successful but deployed nothing.

## Fix

Drop `staging` from the `on: push: branches` list. Master continues to trigger CD normally. Staging code-promotion can still happen via PR merges to a staging branch if desired (the branch isn't deleted), it just won't fire a misleading workflow run.

## Reversibility

When a real staging environment is provisioned in `rfcx-local` (`apps-staging` namespace + `staging.arbimon.org` ingress + a non-gated `Deploy: rfcx-local` job), add `staging` back to the trigger list along with the matching deploy gate. The diff to revert this change is one line.

## Related work tonight

The visualizer fix #2457 already shipped to production via develop → staging → master. PR #2458 (staging promote) merged cleanly but its CD run was the no-op described above; #2459 master-promote CD did the actual deploy.