### PR TITLE
fix(visualizer): break Vue 3.3 flushJobs recursion loop in sidebar-thumbnail (#2461)

### DIFF
--- a/apps/website/src/projects/audiodata/_composables/use-visualizer.ts
+++ b/apps/website/src/projects/audiodata/_composables/use-visualizer.ts
@@ -25,17 +25,38 @@ export const useGetRecording = (apiClient: AxiosInstance, slug: ComputedRef<stri
 }
 
 export const useGetListRecordings = (apiClient: AxiosInstance, slug: ComputedRef<string | undefined>, params: ComputedRef<RecordingSearchParams | undefined>): UseQueryReturnType<RecordingResponse | undefined, unknown> => {
+  // The query is `enabled` only when both slug and params are defined. This
+  // replaces the previous pattern where the queryKey was static
+  // (`['fetch-recordings']`) and callers manually triggered `refetch()` from
+  // `watch(...)` callbacks whenever params changed.
+  //
+  // That manual-refetch pattern caused an infinite reactive loop on the
+  // visualizer page (rfcx/arbimon#2461): the watcher callbacks ran in Vue's
+  // pre-flush phase, called `refetch()`, which synchronously mutated the
+  // query's reactive `state` object via Vue Query's `updateState`. That
+  // synchronous mutation re-entered Vue's component-update cycle while the
+  // pre-flush watchers were still being drained, and Vue 3.3's production
+  // scheduler has no recursion guard (`checkRecursiveUpdates` is
+  // dev-build-only). The renderer thread wedged after ~6 s of runaway
+  // reactivity and Chrome killed it.
+  //
+  // Letting Vue Query own the refetch decision (via `enabled` + a reactive
+  // queryKey) means the work is scheduled asynchronously and never runs
+  // inside the pre-flush watcher path.
+  const enabled = computed(() => Boolean(slug.value && params.value))
   return useQuery({
-    queryKey: ['fetch-recordings'],
+    queryKey: ['fetch-recordings', slug, params],
     queryFn: async () => {
-      if (!slug.value || params.value === undefined) return null
-      return await apiArbimonGetRecordings(apiClient, slug.value, params.value ?? {
+      if (!enabled.value) return null
+      return await apiArbimonGetRecordings(apiClient, slug.value as string, params.value ?? {
         limit: 10,
         offset: 0,
         key: ''
       })
     },
-    retry: 0
+    enabled,
+    retry: 0,
+    refetchOnWindowFocus: false
   })
 }
 

--- a/apps/website/src/projects/audiodata/_composables/use-visualizer.ts
+++ b/apps/website/src/projects/audiodata/_composables/use-visualizer.ts
@@ -47,12 +47,11 @@ export const useGetListRecordings = (apiClient: AxiosInstance, slug: ComputedRef
   return useQuery({
     queryKey: ['fetch-recordings', slug, params],
     queryFn: async () => {
+      // `enabled` already guarantees slug.value + params.value are both truthy,
+      // so the casts are safe. If a caller wires this query without that
+      // guard in the future, `enabled` short-circuits us back to null here.
       if (!enabled.value) return null
-      return await apiArbimonGetRecordings(apiClient, slug.value as string, params.value ?? {
-        limit: 10,
-        offset: 0,
-        key: ''
-      })
+      return await apiArbimonGetRecordings(apiClient, slug.value as string, params.value as RecordingSearchParams)
     },
     enabled,
     retry: 0,

--- a/apps/website/src/projects/audiodata/visualizer/components/sidebar-thumbnail.vue
+++ b/apps/website/src/projects/audiodata/visualizer/components/sidebar-thumbnail.vue
@@ -194,6 +194,12 @@ const onSelectedThumbnail = (id: number) => {
 }
 
 watch(() => recordingsResponse.value, (newValue) => {
+  // Clear the "date-was-just-changed" flag once the response arrives. The
+  // flag tells `recordingListSearchParams` to omit `recording_id` from the
+  // query key so a freshly-selected date doesn't immediately scroll back
+  // onto the previously-active recording. Clearing it here is safe because
+  // the flag is only read inside `recordingListSearchParams`, and that
+  // computed is only consumed by the query whose response just arrived.
   isInitialDateWasChanged.value = false
   if (!newValue || recordingsResponse.value === undefined) return
   if (recordingsResponse.value.length === 0) return
@@ -206,9 +212,12 @@ watch(() => recordingsResponse.value, (newValue) => {
   }
 })
 
-watch(() => browserType.value, () => {
-  refetchRecordings()
-})
+// browserType / props.initialDate / props.siteSelected changes used to call
+// refetchRecordings() directly here. That synchronously mutated the Vue
+// Query reactive state inside Vue's pre-flush phase, which re-entered the
+// component-update cycle and wedged the renderer (rfcx/arbimon#2461). Now
+// that `useGetListRecordings` keys on `params`, Vue Query refetches on its
+// own when any of these inputs change, so the manual refetch is unnecessary.
 
 watch(() => props.recordingsItem, (r) => {
   if (r === undefined) return
@@ -267,14 +276,18 @@ watch(
 )
 
 watch(() => props.initialDate, () => {
+  // Mark that the date was just changed; the next `recordingListSearchParams`
+  // re-evaluation will drop the `recording_id` segment so we don't snap back
+  // to the previously-selected recording. Vue Query picks up the new key
+  // automatically; no manual refetch needed.
   isInitialDateWasChanged.value = true
-  refetchRecordings()
 })
 
 watch(() => props.siteSelected, () => {
   if (siteSelectedRef.value === props.siteSelected || props.siteSelected === undefined) return
   siteSelectedRef.value = props.siteSelected
-  refetchRecordings()
+  // No manual refetch: `recordingListSearchParams` reads `siteSelectedRef`,
+  // so the query key changes and Vue Query refetches asynchronously.
 })
 
 watch(() => props.nextRecording, (newVal) => {


### PR DESCRIPTION
## Closes #2461

Fixes the visualizer-hang bug on `/p/<slug>/visualizer/rec/<id>`.

## TL;DR

Two changes in one composable + one component:

1. Make `useGetListRecordings`'s queryKey reactive on `params` (it was `['fetch-recordings']` — completely static). Add an `enabled` computed.
2. Drop the manual `refetchRecordings()` calls from the three `watch()` callbacks in `sidebar-thumbnail.vue` (`initialDate`, `siteSelected`, `browserType`). Vue Query now refetches on its own when the key changes.

## Root cause (different from the diagnosis attached to #2461)

A CPU profile of the freeze (captured via CDP Tracing, since `Profiler.stop` hangs once the renderer wedges) shows the real loop:

```
flushJobs (Tme)
  → componentUpdateFn (Ae) for sidebar-thumbnail
    → updateComponent (J)
      → flushPreFlushCbs (aoe)
        → watch(() => props.initialDate / siteSelected) callback
          → refetchRecordings()
            → vue-query refetch wrapper (`fix #5910` synchronous shim)
              → updater()
                → updateState(state, observer.getCurrentResult())
                  [mutates Vue Query's reactive `state` object SYNCHRONOUSLY]
                  → Vue's trigger system fires while we're still in pre-flush
                    → componentUpdateFn for sidebar-thumbnail (NESTED Ae)
                      → flushPreFlushCbs again
                        → same watch callback fires again
                          → ... recurses indefinitely
```

The chain repeats until Chrome's renderer-hung detector kills the page. There is **no** Tanstack Vue Query GC scheduler storm; `scheduleGc` setTimeouts are stable at 141 the instant the JS thread wedges. The previous session's diagnosis (attached to the issue) was based on the top `setTimeout` caller in the first 200 samples, but those reflect normal mount churn, not the wedge.

Vue 3.3's production build of `flushJobs` has no recursion guard (`checkRecursiveUpdates` is dev-only in `@vue/runtime-core@3.3.13`'s prod bundle). Vue 3.4+ added a hard `RECURSION_LIMIT`, so we'd also get defense-in-depth from a Vue bump, but that's a much bigger change for another PR.

## Why the manual refetches were there

`useGetListRecordings` had a static queryKey, so Vue Query couldn't see param changes. Callers worked around this by calling `refetch()` manually whenever a relevant input (date, site, browserType) changed. That's the pattern that pulled the refetch into the synchronous pre-flush call stack.

This PR moves `params` into the queryKey so Vue Query's own internal watcher path drives refetches. That path schedules the queryFn off the current flush, which breaks the re-entrancy cycle.

## What's unchanged

- The user-facing key string (`!q:<site>-<date>?recording_id=<id>`) is still built by `recordingListSearchParams` exactly as before; only how it's wired into Vue Query changes.
- `isInitialDateWasChanged` still flips on `initialDate` change and flips back when the response arrives, so a freshly-selected date still drops `recording_id` from the query.
- The infinite-scroll handler still calls `refetchRecordings()` explicitly. That path is event-driven (user scrolls), not reactive, so it can't re-enter the pre-flush cycle.

## CD path

Staging is a no-op since the kops decommission (see PR #2460). Plan is develop → master directly once this is green. Will verify in production after CD finishes by re-running the original repro:

```bash
pkill -9 -f 'Arbimon-Admin'
open /Applications/Arbimon-Admin.app; sleep 6
node implementations/arbimon/admin/cli.js navigate \
  "https://arbimon.org/p/biosoundscape/visualizer/rec/155090002?nocache=$(date +%s)"
sleep 15
node implementations/arbimon/admin/cli.js events tail \
  --kind health.js-blocked --since 30s
# Expected: 0 events. Page should render spectrogram.
```

If `health.js-blocked` fires after deploy, the fix didn't take and we revert.
