### PR TITLE
Promote develop → master: visualizer hang fix (#2462 closes #2461)

### DIFF
--- a/apps/website/src/projects/audiodata/_composables/use-visualizer.ts
+++ b/apps/website/src/projects/audiodata/_composables/use-visualizer.ts
@@ -25,17 +25,38 @@ export const useGetRecording = (apiClient: AxiosInstance, slug: ComputedRef<stri
 }
 
 export const useGetListRecordings = (apiClient: AxiosInstance, slug: ComputedRef<string | undefined>, params: ComputedRef<RecordingSearchParams | undefined>): UseQueryReturnType<RecordingResponse | undefined, unknown> => {
+  // The query is `enabled` only when both slug and params are defined. This
+  // replaces the previous pattern where the queryKey was static
+  // (`['fetch-recordings']`) and callers manually triggered `refetch()` from
+  // `watch(...)` callbacks whenever params changed.
+  //
+  // That manual-refetch pattern caused an infinite reactive loop on the
+  // visualizer page (rfcx/arbimon#2461): the watcher callbacks ran in Vue's
+  // pre-flush phase, called `refetch()`, which synchronously mutated the
+  // query's reactive `state` object via Vue Query's `updateState`. That
+  // synchronous mutation re-entered Vue's component-update cycle while the
+  // pre-flush watchers were still being drained, and Vue 3.3's production
+  // scheduler has no recursion guard (`checkRecursiveUpdates` is
+  // dev-build-only). The renderer thread wedged after ~6 s of runaway
+  // reactivity and Chrome killed it.
+  //
+  // Letting Vue Query own the refetch decision (via `enabled` + a reactive
+  // queryKey) means the work is scheduled asynchronously and never runs
+  // inside the pre-flush watcher path.
+  const enabled = computed(() => Boolean(slug.value && params.value))
   return useQuery({
-    queryKey: ['fetch-recordings'],
+    queryKey: ['fetch-recordings', slug, params],
     queryFn: async () => {
-      if (!slug.value || params.value === undefined) return null
-      return await apiArbimonGetRecordings(apiClient, slug.value, params.value ?? {
+      if (!enabled.value) return null
+      return await apiArbimonGetRecordings(apiClient, slug.value as string, params.value ?? {
         limit: 10,
         offset: 0,
         key: ''
       })
     },
-    retry: 0
+    enabled,
+    retry: 0,
+    refetchOnWindowFocus: false
   })
 }
 

--- a/apps/website/src/projects/audiodata/_composables/use-visualizer.ts
+++ b/apps/website/src/projects/audiodata/_composables/use-visualizer.ts
@@ -47,12 +47,11 @@ export const useGetListRecordings = (apiClient: AxiosInstance, slug: ComputedRef
   return useQuery({
     queryKey: ['fetch-recordings', slug, params],
     queryFn: async () => {
+      // `enabled` already guarantees slug.value + params.value are both truthy,
+      // so the casts are safe. If a caller wires this query without that
+      // guard in the future, `enabled` short-circuits us back to null here.
       if (!enabled.value) return null
-      return await apiArbimonGetRecordings(apiClient, slug.value as string, params.value ?? {
-        limit: 10,
-        offset: 0,
-        key: ''
-      })
+      return await apiArbimonGetRecordings(apiClient, slug.value as string, params.value as RecordingSearchParams)
     },
     enabled,
     retry: 0,

--- a/apps/website/src/projects/audiodata/visualizer/components/sidebar-thumbnail.vue
+++ b/apps/website/src/projects/audiodata/visualizer/components/sidebar-thumbnail.vue
@@ -194,6 +194,12 @@ const onSelectedThumbnail = (id: number) => {
 }
 
 watch(() => recordingsResponse.value, (newValue) => {
+  // Clear the "date-was-just-changed" flag once the response arrives. The
+  // flag tells `recordingListSearchParams` to omit `recording_id` from the
+  // query key so a freshly-selected date doesn't immediately scroll back
+  // onto the previously-active recording. Clearing it here is safe because
+  // the flag is only read inside `recordingListSearchParams`, and that
+  // computed is only consumed by the query whose response just arrived.
   isInitialDateWasChanged.value = false
   if (!newValue || recordingsResponse.value === undefined) return
   if (recordingsResponse.value.length === 0) return
@@ -206,9 +212,12 @@ watch(() => recordingsResponse.value, (newValue) => {
   }
 })
 
-watch(() => browserType.value, () => {
-  refetchRecordings()
-})
+// browserType / props.initialDate / props.siteSelected changes used to call
+// refetchRecordings() directly here. That synchronously mutated the Vue
+// Query reactive state inside Vue's pre-flush phase, which re-entered the
+// component-update cycle and wedged the renderer (rfcx/arbimon#2461). Now
+// that `useGetListRecordings` keys on `params`, Vue Query refetches on its
+// own when any of these inputs change, so the manual refetch is unnecessary.
 
 watch(() => props.recordingsItem, (r) => {
   if (r === undefined) return
@@ -267,14 +276,18 @@ watch(
 )
 
 watch(() => props.initialDate, () => {
+  // Mark that the date was just changed; the next `recordingListSearchParams`
+  // re-evaluation will drop the `recording_id` segment so we don't snap back
+  // to the previously-selected recording. Vue Query picks up the new key
+  // automatically; no manual refetch needed.
   isInitialDateWasChanged.value = true
-  refetchRecordings()
 })
 
 watch(() => props.siteSelected, () => {
   if (siteSelectedRef.value === props.siteSelected || props.siteSelected === undefined) return
   siteSelectedRef.value = props.siteSelected
-  refetchRecordings()
+  // No manual refetch: `recordingListSearchParams` reads `siteSelectedRef`,
+  // so the query key changes and Vue Query refetches asynchronously.
 })
 
 watch(() => props.nextRecording, (newVal) => {


### PR DESCRIPTION
Promote develop → master.

## What's promoting

Three commits, all in the visualizer-hang fix lineage (PR #2462, closes #2461):

- `473291e3` fix(visualizer): break Vue 3.3 flushJobs recursion loop in sidebar-thumbnail
- `a50885a2` fix(visualizer): drop unreachable hardcoded params fallback (vue-tsc)
- `f048f228` Merge pull request #2462

## Why direct to master (no staging)

Staging push currently triggers a no-op CD (`apps-prod` namespace gating means every deploy step skips when branch != master since the kops decom). PR #2460 removes the staging trigger from `cd.yaml`; that PR is still open but doesn't block this promotion.

## Post-merge verification plan

CD takes ~5–10 min to build + roll out `biodiversity-website` to rfcx-local prod. Once it's done, I'll re-run the original repro:

```bash
pkill -9 -f 'Arbimon-Admin'
open /Applications/Arbimon-Admin.app; sleep 6
node implementations/arbimon/admin/cli.js navigate \
  "https://arbimon.org/p/biosoundscape/visualizer/rec/155090002?nocache=$(date +%s)"
sleep 15
node implementations/arbimon/admin/cli.js events tail \
  --kind health.js-blocked --since 30s
```

Expected: 0 `health.js-blocked` events. If the watchdog fires anyway, this PR gets reverted via a fresh `git revert` PR (no force-push to master).

If the wedge is gone but the page still shows "Loading…" forever, that's a separate issue: `/legacy-api/project/<slug>/recordings/info/<id>` isn't firing server-side. Need to investigate the backend (probably arbimon-legacy `babecb41`, the asset-url helper, although it shouldn't affect that endpoint's response shape — needs follow-up).