### PR TITLE
Promote develop → master: visualizer hang fix v2 (#2464 closes #2461)

### DIFF
--- a/apps/website/src/_components/date-range-picker/date-input-picker.vue
+++ b/apps/website/src/_components/date-range-picker/date-input-picker.vue
@@ -161,6 +161,12 @@ onMounted(async () => {
     const dates = picker.value?.getDate()
     if (dates === undefined || dates === null || !(dates instanceof Date)) return
     const dateIso = dayjs(dates).format('YYYY-MM-DD') + 'T00:00:00.000Z'
+    // Defense in depth against the rfcx/arbimon#2461 feedback loop: don't
+    // re-emit `emitSelectDate` when the picker fires `changeDate` with a
+    // value we already published. The setDate guard in `watch(initialDate)`
+    // is the primary fix; this is a belt-and-braces check against any other
+    // future code path that ends up calling `setDate` with the same value.
+    if (dateIso === selectedDateIso.value) return
     selectedDateIso.value = dateIso
     emit('emitSelectDate', { dateLocalIso: dateIso })
   })
@@ -176,8 +182,22 @@ watch(() => props.initialDate, (v) => {
     selectedDateIso.value = ''
   } else {
     const formatted = dayjs(v).format(format)
-    picker.value?.setDate(formatted)
-    if (datePickerInput.value) datePickerInput.value.value = formatted
+    // Guard: only push the new date into the flatpickr instance when it
+    // *actually* differs from what's already displayed. `picker.setDate()`
+    // unconditionally dispatches a `changeDate` event, and the listener
+    // installed below emits `emitSelectDate` to the parent, which mutates
+    // its own `initialDate` ref — which propagates back as `props.initialDate`
+    // to *this* component, re-firing this watcher. Vue 3.3's production
+    // scheduler has no `RECURSION_LIMIT` (see Vue 3.4+'s `checkRecursiveUpdates`
+    // wrapped in a dev-only branch in @vue/runtime-core@3.3.13), so the loop
+    // is unbounded and wedges the renderer thread within ~6 s. Skipping the
+    // setDate when the value is already current breaks the cycle without
+    // changing any user-visible behaviour (the picker is already showing
+    // the right date). See rfcx/arbimon#2461.
+    if (datePickerInput.value?.value !== formatted) {
+      picker.value?.setDate(formatted)
+      if (datePickerInput.value) datePickerInput.value.value = formatted
+    }
     selectedDateIso.value = dayjs(props.initialDate).format('YYYY-MM-DD') + 'T00:00:00.000Z'
   }
 })


### PR DESCRIPTION
Promote develop → master, carrying PR #2464 — the actual fix for the visualizer hang (#2461).

## What's promoting

- `0d530bc73` fix(date-input-picker): break setDate→changeDate→emit→initialDate loop (#2461)
- `fa5ffb224` Merge PR #2464

## Why direct to master

Staging push currently triggers a no-op CD (#2460 still open). Direct develop → master is the documented path right now.

## Post-merge verification

CD takes ~5–10 min to roll out `biodiversity-website` to rfcx-local prod. After deploy:

```bash
pkill -9 -f 'Arbimon-Admin'
open /Applications/Arbimon-Admin.app; sleep 6
node implementations/arbimon/admin/cli.js navigate \
  "https://arbimon.org/p/biosoundscape/visualizer/rec/155090002?nocache=$(date +%s)"
sleep 15
node implementations/arbimon/admin/cli.js events tail \
  --kind health.js-blocked --since 30s
```

Expected: 0 `health.js-blocked` events. Page renders the spectrogram.

If the watchdog still fires, revert via fresh `git revert` PR (no force-push to master) and dig further. Recordings/info would still need to actually load server-side for the spectrogram to render, but the renderer wedge should be gone either way.