### PR TITLE
chore(analytics): disable vue-gtag site-wide while investigating #2461

### DIFF
--- a/apps/website/src/_services/analytics/index.ts
+++ b/apps/website/src/_services/analytics/index.ts
@@ -4,5 +4,16 @@ export const ANALYTICS_CONFIGS = {
   config: {
     id: import.meta.env.VITE_GA_MEASUREMENT_ID
   },
-  pageTrackerEnabled: true
+  pageTrackerEnabled: true,
+  // Temporarily disabled while investigating the visualizer-page hang
+  // (rfcx/arbimon#2461). The bug reproduces even with GA's network calls
+  // blocked at the renderer level, so GA is unlikely to be the trigger, but
+  // we want a clean signal in production while bisecting the wedge. Setting
+  // `enabled: false` short-circuits vue-gtag's bootstrap so neither
+  // gtag/js?id=G-30S3SHR2JZ nor G-RJJTZ45WJB is loaded and no
+  // googletagmanager / google-analytics scripts run. `import { event }` calls
+  // from dashboard-markdown-viewer-editor become safe no-ops in this state
+  // (vue-gtag@2.0.1 contract). Re-enable after #2461 is resolved.
+  enabled: false,
+  disableScriptLoad: true
 }


### PR DESCRIPTION
Temporarily disables vue-gtag across the whole web app while we bisect the visualizer hang (#2461). One-line behavioural change in `apps/website/src/_services/analytics/index.ts`:

```diff
   pageTrackerEnabled: true,
+  enabled: false,
+  disableScriptLoad: true
```

## What this does

- vue-gtag's plugin install becomes a no-op
- `gtag/js?id=G-30S3SHR2JZ` and `gtag/js?id=G-RJJTZ45WJB` are not loaded
- googletagmanager.com / google-analytics.com fetches don't fire
- `import { event } from 'vue-gtag'` in `dashboard-markdown-viewer-editor.vue` still imports cleanly; the calls become no-ops per vue-gtag@2.0.1's contract

## Why

We already confirmed the visualizer wedge reproduces with GA blocked at the renderer level (intercepted `<script src>` for both GTM IDs), so GA isn't the trigger. But:

1. The Arbimon-Admin diagnostic browser has google-analytics.com / googletagmanager.com DNS blocked, so every page load was wasting cycles on the fail-and-retry path.
2. The CPU profiles were noisy with gtm.js `setTimeout` chains, which made earlier traces harder to interpret.
3. Topher's call: get a clean production baseline while we bisect.

## Reversible

Remove the two added lines and GA is back. No other code changes needed; the import surface for `vue-gtag` is unchanged.

## Verification plan after CD

```bash
# 1. Confirm GA scripts no longer load
curl -s 'https://arbimon.org/p/biosoundscape/visualizer/rec/155090002' | grep -c googletagmanager
# Expected: 0 in the inline HTML. (vue-gtag injects scripts at runtime, so also check DevTools Network for any gtm/ga requests.)

# 2. Re-run the wedge repro
pkill -9 -f 'Arbimon-Admin'
open /Applications/Arbimon-Admin.app; sleep 6
node implementations/arbimon/admin/cli.js navigate \
  "https://arbimon.org/p/biosoundscape/visualizer/rec/155090002?nocache=$(date +%s)"
sleep 15
node implementations/arbimon/admin/cli.js events tail \
  --kind health.js-blocked --since 30s
```

We expect this to still wedge (we've already confirmed GA is not the trigger), but the trace should now be free of gtm/ga setTimeout noise, which lets us see the real reactive cascade more clearly.