### PR TITLE
Promote develop → master: disable vue-gtag site-wide (#2466)

### DIFF
--- a/apps/website/src/_services/analytics/index.ts
+++ b/apps/website/src/_services/analytics/index.ts
@@ -4,5 +4,16 @@ export const ANALYTICS_CONFIGS = {
   config: {
     id: import.meta.env.VITE_GA_MEASUREMENT_ID
   },
-  pageTrackerEnabled: true
+  pageTrackerEnabled: true,
+  // Temporarily disabled while investigating the visualizer-page hang
+  // (rfcx/arbimon#2461). The bug reproduces even with GA's network calls
+  // blocked at the renderer level, so GA is unlikely to be the trigger, but
+  // we want a clean signal in production while bisecting the wedge. Setting
+  // `enabled: false` short-circuits vue-gtag's bootstrap so neither
+  // gtag/js?id=G-30S3SHR2JZ nor G-RJJTZ45WJB is loaded and no
+  // googletagmanager / google-analytics scripts run. `import { event }` calls
+  // from dashboard-markdown-viewer-editor become safe no-ops in this state
+  // (vue-gtag@2.0.1 contract). Re-enable after #2461 is resolved.
+  enabled: false,
+  disableScriptLoad: true
 }


### PR DESCRIPTION
Promotes PR #2466 (disable vue-gtag while investigating #2461).

One file changed: `apps/website/src/_services/analytics/index.ts` gains `enabled: false` and `disableScriptLoad: true`. Behavioural effect: GA / GTM scripts stop loading and firing across the whole web app.

Will verify with the standard repro after CD completes (~5–10 min).