### PR TITLE
Promote develop → master: revert #2462 + #2464 (#2470)

### DIFF
--- a/apps/website/src/_components/date-range-picker/date-input-picker.vue
+++ b/apps/website/src/_components/date-range-picker/date-input-picker.vue
@@ -161,12 +161,6 @@ onMounted(async () => {
     const dates = picker.value?.getDate()
     if (dates === undefined || dates === null || !(dates instanceof Date)) return
     const dateIso = dayjs(dates).format('YYYY-MM-DD') + 'T00:00:00.000Z'
-    // Defense in depth against the rfcx/arbimon#2461 feedback loop: don't
-    // re-emit `emitSelectDate` when the picker fires `changeDate` with a
-    // value we already published. The setDate guard in `watch(initialDate)`
-    // is the primary fix; this is a belt-and-braces check against any other
-    // future code path that ends up calling `setDate` with the same value.
-    if (dateIso === selectedDateIso.value) return
     selectedDateIso.value = dateIso
     emit('emitSelectDate', { dateLocalIso: dateIso })
   })
@@ -182,22 +176,8 @@ watch(() => props.initialDate, (v) => {
     selectedDateIso.value = ''
   } else {
     const formatted = dayjs(v).format(format)
-    // Guard: only push the new date into the flatpickr instance when it
-    // *actually* differs from what's already displayed. `picker.setDate()`
-    // unconditionally dispatches a `changeDate` event, and the listener
-    // installed below emits `emitSelectDate` to the parent, which mutates
-    // its own `initialDate` ref — which propagates back as `props.initialDate`
-    // to *this* component, re-firing this watcher. Vue 3.3's production
-    // scheduler has no `RECURSION_LIMIT` (see Vue 3.4+'s `checkRecursiveUpdates`
-    // wrapped in a dev-only branch in @vue/runtime-core@3.3.13), so the loop
-    // is unbounded and wedges the renderer thread within ~6 s. Skipping the
-    // setDate when the value is already current breaks the cycle without
-    // changing any user-visible behaviour (the picker is already showing
-    // the right date). See rfcx/arbimon#2461.
-    if (datePickerInput.value?.value !== formatted) {
-      picker.value?.setDate(formatted)
-      if (datePickerInput.value) datePickerInput.value.value = formatted
-    }
+    picker.value?.setDate(formatted)
+    if (datePickerInput.value) datePickerInput.value.value = formatted
     selectedDateIso.value = dayjs(props.initialDate).format('YYYY-MM-DD') + 'T00:00:00.000Z'
   }
 })

--- a/apps/website/src/projects/audiodata/_composables/use-visualizer.ts
+++ b/apps/website/src/projects/audiodata/_composables/use-visualizer.ts
@@ -25,37 +25,17 @@ export const useGetRecording = (apiClient: AxiosInstance, slug: ComputedRef<stri
 }
 
 export const useGetListRecordings = (apiClient: AxiosInstance, slug: ComputedRef<string | undefined>, params: ComputedRef<RecordingSearchParams | undefined>): UseQueryReturnType<RecordingResponse | undefined, unknown> => {
-  // The query is `enabled` only when both slug and params are defined. This
-  // replaces the previous pattern where the queryKey was static
-  // (`['fetch-recordings']`) and callers manually triggered `refetch()` from
-  // `watch(...)` callbacks whenever params changed.
-  //
-  // That manual-refetch pattern caused an infinite reactive loop on the
-  // visualizer page (rfcx/arbimon#2461): the watcher callbacks ran in Vue's
-  // pre-flush phase, called `refetch()`, which synchronously mutated the
-  // query's reactive `state` object via Vue Query's `updateState`. That
-  // synchronous mutation re-entered Vue's component-update cycle while the
-  // pre-flush watchers were still being drained, and Vue 3.3's production
-  // scheduler has no recursion guard (`checkRecursiveUpdates` is
-  // dev-build-only). The renderer thread wedged after ~6 s of runaway
-  // reactivity and Chrome killed it.
-  //
-  // Letting Vue Query own the refetch decision (via `enabled` + a reactive
-  // queryKey) means the work is scheduled asynchronously and never runs
-  // inside the pre-flush watcher path.
-  const enabled = computed(() => Boolean(slug.value && params.value))
   return useQuery({
-    queryKey: ['fetch-recordings', slug, params],
+    queryKey: ['fetch-recordings'],
     queryFn: async () => {
-      // `enabled` already guarantees slug.value + params.value are both truthy,
-      // so the casts are safe. If a caller wires this query without that
-      // guard in the future, `enabled` short-circuits us back to null here.
-      if (!enabled.value) return null
-      return await apiArbimonGetRecordings(apiClient, slug.value as string, params.value as RecordingSearchParams)
+      if (!slug.value || params.value === undefined) return null
+      return await apiArbimonGetRecordings(apiClient, slug.value, params.value ?? {
+        limit: 10,
+        offset: 0,
+        key: ''
+      })
     },
-    enabled,
-    retry: 0,
-    refetchOnWindowFocus: false
+    retry: 0
   })
 }
 

--- a/apps/website/src/projects/audiodata/visualizer/components/sidebar-thumbnail.vue
+++ b/apps/website/src/projects/audiodata/visualizer/components/sidebar-thumbnail.vue
@@ -194,12 +194,6 @@ const onSelectedThumbnail = (id: number) => {
 }
 
 watch(() => recordingsResponse.value, (newValue) => {
-  // Clear the "date-was-just-changed" flag once the response arrives. The
-  // flag tells `recordingListSearchParams` to omit `recording_id` from the
-  // query key so a freshly-selected date doesn't immediately scroll back
-  // onto the previously-active recording. Clearing it here is safe because
-  // the flag is only read inside `recordingListSearchParams`, and that
-  // computed is only consumed by the query whose response just arrived.
   isInitialDateWasChanged.value = false
   if (!newValue || recordingsResponse.value === undefined) return
   if (recordingsResponse.value.length === 0) return
@@ -212,12 +206,9 @@ watch(() => recordingsResponse.value, (newValue) => {
   }
 })
 
-// browserType / props.initialDate / props.siteSelected changes used to call
-// refetchRecordings() directly here. That synchronously mutated the Vue
-// Query reactive state inside Vue's pre-flush phase, which re-entered the
-// component-update cycle and wedged the renderer (rfcx/arbimon#2461). Now
-// that `useGetListRecordings` keys on `params`, Vue Query refetches on its
-// own when any of these inputs change, so the manual refetch is unnecessary.
+watch(() => browserType.value, () => {
+  refetchRecordings()
+})
 
 watch(() => props.recordingsItem, (r) => {
   if (r === undefined) return
@@ -276,18 +267,14 @@ watch(
 )
 
 watch(() => props.initialDate, () => {
-  // Mark that the date was just changed; the next `recordingListSearchParams`
-  // re-evaluation will drop the `recording_id` segment so we don't snap back
-  // to the previously-selected recording. Vue Query picks up the new key
-  // automatically; no manual refetch needed.
   isInitialDateWasChanged.value = true
+  refetchRecordings()
 })
 
 watch(() => props.siteSelected, () => {
   if (siteSelectedRef.value === props.siteSelected || props.siteSelected === undefined) return
   siteSelectedRef.value = props.siteSelected
-  // No manual refetch: `recordingListSearchParams` reads `siteSelectedRef`,
-  // so the query key changes and Vue Query refetches asynchronously.
+  refetchRecordings()
 })
 
 watch(() => props.nextRecording, (newVal) => {


### PR DESCRIPTION
Promotes PR #2470 — reverts the two failed visualizer-fix attempts (#2462 and #2464). Neither resolved the visualizer hang (#2461), both have been verified ineffective in production.

After this lands, master is back to the pre-#2462 baseline for `use-visualizer.ts`, `sidebar-thumbnail.vue`, and `date-input-picker.vue`. The GA disable (#2466 / #2468) remains on master.

Wedge will still reproduce — that's the expected outcome of a baseline revert. Tomorrow's investigation will start from a clean diff.