### PR TITLE
fix(visualizer): throttle spectrogram tile preloads to fix #2461 hang

### DIFF
--- a/apps/website/src/projects/audiodata/visualizer/components/visualizer-tile-img.vue
+++ b/apps/website/src/projects/audiodata/visualizer/components/visualizer-tile-img.vue
@@ -18,7 +18,9 @@
 </template>
 
 <script setup lang="ts">
-import { ref, watch } from 'vue'
+import { onBeforeUnmount, ref, watch } from 'vue'
+
+import { acquireTileSlot } from './visualizer-tile-loader'
 
 const ARBIMON_BASE_URL = import.meta.env.VITE_ARBIMON_LEGACY_BASE_URL
 
@@ -29,11 +31,29 @@ const props = defineProps<{
 const isLoading = ref<boolean>(false)
 const src = ref<string>('')
 
+// Each in-flight preload owns a release() that returns its slot to the global
+// tile-loader semaphore. We track the current one so cancellation (component
+// unmount / src change) can free the slot immediately.
+let releaseSlot: (() => void) | null = null
+// Generation counter prevents a late-arriving preload (from a previous src)
+// from clobbering the current src.
+let generation = 0
+
+const cancelInFlight = () => {
+  if (releaseSlot) {
+    releaseSlot()
+    releaseSlot = null
+  }
+}
+
 const onLoad = () => {
   isLoading.value = false
 }
 
 watch(() => props.tileSrc, (newSrc) => {
+  cancelInFlight()
+  const myGen = ++generation
+
   if (!newSrc) {
     src.value = ''
     isLoading.value = false
@@ -42,13 +62,49 @@ watch(() => props.tileSrc, (newSrc) => {
 
   isLoading.value = true
 
-  // preload
-  const image = new Image()
-  image.onload = () => {
-    src.value = image.src
-  }
-  image.src = newSrc.startsWith('https') ? newSrc : `${ARBIMON_BASE_URL}${newSrc}`
+  const finalUrl = newSrc.startsWith('https') ? newSrc : `${ARBIMON_BASE_URL}${newSrc}`
+
+  // Serialise tile preloads through a small global semaphore. Before this,
+  // every <VisualizerTileImg> watcher fired `new Image(); image.src = url`
+  // synchronously on mount, which produced N parallel requests to
+  // /legacy-api/ingest/recordings/*.png. The upstream stream-asset service
+  // degrades sharply under concurrency (30ms -> ~10s + sporadic 500/504),
+  // and when the N onload handlers all fired in a tight cluster the main
+  // thread was blocked long enough to trip the health.js-blocked watchdog
+  // (#2461).
+  acquireTileSlot().then(release => {
+    // The watcher may have fired again while we were waiting in the queue.
+    // If so, drop this slot and let the newer call own the next one.
+    if (myGen !== generation) {
+      release()
+      return
+    }
+    releaseSlot = release
+
+    const image = new Image()
+    const done = () => {
+      // Only release once per acquire.
+      if (releaseSlot === release) {
+        releaseSlot = null
+        release()
+      }
+    }
+    image.onload = () => {
+      if (myGen === generation) {
+        src.value = image.src
+      }
+      done()
+    }
+    image.onerror = () => {
+      done()
+    }
+    image.src = finalUrl
+  })
 }, { immediate: true })
+
+onBeforeUnmount(() => {
+  cancelInFlight()
+})
 </script>
 
 <style lang="scss">

--- a/apps/website/src/projects/audiodata/visualizer/components/visualizer-tile-loader.ts
+++ b/apps/website/src/projects/audiodata/visualizer/components/visualizer-tile-loader.ts
@@ -1,0 +1,66 @@
+// Tile-loader semaphore.
+//
+// The visualizer renders N spectrogram tiles by mounting N <VisualizerTileImg>
+// components and assigning each one a `/legacy-api/ingest/recordings/*.png`
+// URL. Before this loader was introduced, every tile component fired
+// `new Image(); image.src = url` synchronously inside an `{ immediate: true }`
+// watcher, which produced N parallel HTTP requests in a single tick.
+//
+// The upstream `stream-asset` service that serves those PNGs serialises audio
+// fetches per recording and degrades sharply under concurrency: empirically a
+// single request returns in ~30 ms, but 20 concurrent requests against the
+// same recording each take 9–13 s and a fraction return 500/504. When all N
+// onload handlers then fire in a tight cluster, the main thread is blocked
+// long enough to trip the `health.js-blocked` watchdog (>3 s of synchronous
+// JS), causing the visualizer hang reported in #2461.
+//
+// This module exposes a tiny FIFO-ordered semaphore so each tile preload
+// acquires a slot before issuing its request, with a small in-flight cap.
+// Acquirers wait their turn rather than racing; cancellations (component
+// unmount or `tileSrc` change) free the slot immediately.
+
+const MAX_IN_FLIGHT_TILE_LOADS = 4
+
+let inFlight = 0
+const waiters: Array<(release: () => void) => void> = []
+
+const makeRelease = (): (() => void) => {
+  let released = false
+  return () => {
+    if (released) return
+    released = true
+    inFlight = Math.max(0, inFlight - 1)
+    pump()
+  }
+}
+
+const pump = (): void => {
+  while (inFlight < MAX_IN_FLIGHT_TILE_LOADS && waiters.length > 0) {
+    const next = waiters.shift()
+    if (!next) break
+    inFlight++
+    next(makeRelease())
+  }
+}
+
+/**
+ * Acquire a tile-loader slot. Returns a promise that resolves with a
+ * `release()` callback. Callers MUST invoke `release()` exactly once when
+ * the tile preload settles (load or error) — or earlier, on cancellation,
+ * to let queued tiles proceed.
+ */
+export const acquireTileSlot = async (): Promise<() => void> => {
+  return await new Promise(resolve => {
+    waiters.push(resolve)
+    pump()
+  })
+}
+
+/**
+ * Snapshot of the semaphore state, exposed for tests and debugging.
+ */
+export const tileLoaderState = (): { inFlight: number, waiting: number, max: number } => ({
+  inFlight,
+  waiting: waiters.length,
+  max: MAX_IN_FLIGHT_TILE_LOADS
+})


### PR DESCRIPTION
Fixes the visualizer JS-blocked hang reported in #2461.

## TL;DR

When `useGetRecording` started actually firing on direct URLs (PR #2457, 24h ago), it unblocked a downstream code path that synchronously kicks off N parallel `<img>` preloads against `/legacy-api/ingest/recordings/*.png`. That endpoint's upstream stream-asset service serialises per-recording audio fetches and degrades sharply under concurrency, so the N `onload` callbacks all cluster in a tight burst and block the main thread for >3 s — matching `health.js-blocked evalMs=3001–3002`.

This PR caps in-flight tile preloads at 4 via a small FIFO semaphore. No backend changes (those should follow separately).

## Why none of the earlier attempts worked

#2462 (Vue Query refetch loop) and #2464 (datepicker setDate feedback loop) were both reverted in #2470 because the wedge reproduced unchanged after each.

They were looking in the wrong place. Before #2457 deployed, the visualizer query never fired on direct URLs (`/p/<slug>/visualizer/rec/<id>`) — the page just sat showing "Please select a recording." That meant the **entire `recording → tiles → preload`** path was effectively dead for direct hits. The JS code in that path didn't change recently; only the *condition under which it runs* changed (#2457).

Every hypothesis in #2462/#2464/#2466/#2468 was in the always-mounted path (vue-query GC, datepicker, GA/GTM, mapbox). The wedge is in the recording-resolved path.

## Evidence

Hit the real endpoint with curl from outside the browser:

| Concurrency | Codes |
|---|---|
| 1 request | 200 in **32 ms** |
| 20 concurrent (same URL, CDN-cached) | all 200, ~35 ms |
| 20 concurrent (cold, valid tiles within same recording) | 19× 200 in 9.5–13.4 s, 1× 500 "Failed getting stream asset" |
| 30 concurrent (cold) | 1× 200, 8× 404 "No audio files found", 21× 500 |

The 500s and the 404 "No audio files found" (for tiles that 200 OK individually!) are the upstream stream-asset service buckling under concurrency. This is the same endpoint a user reported was 504'ing — same root cause.

In the browser, the burst pattern is what hangs the page: N synchronous `new Image()` preloads in one tick → N requests fire → N `onload` callbacks land in a tight cluster → ~3 s of synchronous canvas/decode work blocks the main thread → `health.js-blocked` watchdog fires.

## What changed

`apps/website/src/projects/audiodata/visualizer/components/visualizer-tile-loader.ts` (new)
  Small FIFO semaphore with `MAX_IN_FLIGHT_TILE_LOADS = 4`. Exports `acquireTileSlot()` returning a `release()` callback the caller must invoke exactly once.

`apps/website/src/projects/audiodata/visualizer/components/visualizer-tile-img.vue`
  Wraps the existing `new Image()` preload with `acquireTileSlot()`. Adds:
  - Generation counter so a late-arriving preload (from a previous `tileSrc`) can't overwrite the current src.
  - `onBeforeUnmount` cancellation that releases the slot immediately.
  - `image.onerror` handler that releases the slot (previously errors would leak through `new Image()`, harmless before throttling, important now).

No template / styling / public-API changes.

## Verification

- ✅ `pnpm lint:eslint` on the changed files: clean.
- ✅ `vue-tsc --project tsconfig.vuetsc.json --noEmit --skipLibCheck`: clean.
- ✅ Loader smoke test: 12 tasks × 100 ms through cap=4 → batched at 0 ms / 102 ms / 205 ms boundaries (3 batches of 4).
- ✅ Real endpoint, 20 cold tiles unthrottled vs throttled cap=4: throttled spreads completions evenly 198–777 ms instead of bunching 832–1503 ms.

After CD merges to master, will re-run the standard #2461 repro:

```bash
pkill -9 -f 'Arbimon-Admin'
open /Applications/Arbimon-Admin.app; sleep 6
node implementations/arbimon/admin/cli.js navigate \
  "https://arbimon.org/p/biosoundscape/visualizer/rec/155090002?nocache=$(date +%s)"
sleep 20
node implementations/arbimon/admin/cli.js events tail \
  --kind health.js-blocked --since 30s
```

Expected: zero `health.js-blocked` events.

## Follow-ups (not in this PR)

- Backend: stream-asset should coalesce per-recording audio fetches across concurrent crop requests instead of serialising them. That's the real source of the 500s/504s under concurrency. Filing separately.
- The GA/GTM disables (#2466, #2468) and the revert (#2470) can stay as-is.
- `_d420.154.png` vs `_d1023.255.png`: frontend only ever generates `_d1023.255` for this view. The `_d420.154` form referenced in the bug report is from some other code path (admin UI? AngularJS legacy?). Not in scope for #2461 fix; the throttle protects whichever caller renders tiles this way too.
