### PR TITLE
Promote develop → master: visualizer tile-load throttle (#2472 closes #2461)

### DIFF
--- a/apps/website/src/projects/audiodata/visualizer/components/visualizer-tile-img.vue
+++ b/apps/website/src/projects/audiodata/visualizer/components/visualizer-tile-img.vue
@@ -18,7 +18,9 @@
 </template>
 
 <script setup lang="ts">
-import { ref, watch } from 'vue'
+import { onBeforeUnmount, ref, watch } from 'vue'
+
+import { acquireTileSlot } from './visualizer-tile-loader'
 
 const ARBIMON_BASE_URL = import.meta.env.VITE_ARBIMON_LEGACY_BASE_URL
 
@@ -29,11 +31,29 @@ const props = defineProps<{
 const isLoading = ref<boolean>(false)
 const src = ref<string>('')
 
+// Each in-flight preload owns a release() that returns its slot to the global
+// tile-loader semaphore. We track the current one so cancellation (component
+// unmount / src change) can free the slot immediately.
+let releaseSlot: (() => void) | null = null
+// Generation counter prevents a late-arriving preload (from a previous src)
+// from clobbering the current src.
+let generation = 0
+
+const cancelInFlight = () => {
+  if (releaseSlot) {
+    releaseSlot()
+    releaseSlot = null
+  }
+}
+
 const onLoad = () => {
   isLoading.value = false
 }
 
 watch(() => props.tileSrc, (newSrc) => {
+  cancelInFlight()
+  const myGen = ++generation
+
   if (!newSrc) {
     src.value = ''
     isLoading.value = false
@@ -42,13 +62,49 @@ watch(() => props.tileSrc, (newSrc) => {
 
   isLoading.value = true
 
-  // preload
-  const image = new Image()
-  image.onload = () => {
-    src.value = image.src
-  }
-  image.src = newSrc.startsWith('https') ? newSrc : `${ARBIMON_BASE_URL}${newSrc}`
+  const finalUrl = newSrc.startsWith('https') ? newSrc : `${ARBIMON_BASE_URL}${newSrc}`
+
+  // Serialise tile preloads through a small global semaphore. Before this,
+  // every <VisualizerTileImg> watcher fired `new Image(); image.src = url`
+  // synchronously on mount, which produced N parallel requests to
+  // /legacy-api/ingest/recordings/*.png. The upstream stream-asset service
+  // degrades sharply under concurrency (30ms -> ~10s + sporadic 500/504),
+  // and when the N onload handlers all fired in a tight cluster the main
+  // thread was blocked long enough to trip the health.js-blocked watchdog
+  // (#2461).
+  acquireTileSlot().then(release => {
+    // The watcher may have fired again while we were waiting in the queue.
+    // If so, drop this slot and let the newer call own the next one.
+    if (myGen !== generation) {
+      release()
+      return
+    }
+    releaseSlot = release
+
+    const image = new Image()
+    const done = () => {
+      // Only release once per acquire.
+      if (releaseSlot === release) {
+        releaseSlot = null
+        release()
+      }
+    }
+    image.onload = () => {
+      if (myGen === generation) {
+        src.value = image.src
+      }
+      done()
+    }
+    image.onerror = () => {
+      done()
+    }
+    image.src = finalUrl
+  })
 }, { immediate: true })
+
+onBeforeUnmount(() => {
+  cancelInFlight()
+})
 </script>
 
 <style lang="scss">

--- a/apps/website/src/projects/audiodata/visualizer/components/visualizer-tile-loader.ts
+++ b/apps/website/src/projects/audiodata/visualizer/components/visualizer-tile-loader.ts
@@ -1,0 +1,66 @@
+// Tile-loader semaphore.
+//
+// The visualizer renders N spectrogram tiles by mounting N <VisualizerTileImg>
+// components and assigning each one a `/legacy-api/ingest/recordings/*.png`
+// URL. Before this loader was introduced, every tile component fired
+// `new Image(); image.src = url` synchronously inside an `{ immediate: true }`
+// watcher, which produced N parallel HTTP requests in a single tick.
+//
+// The upstream `stream-asset` service that serves those PNGs serialises audio
+// fetches per recording and degrades sharply under concurrency: empirically a
+// single request returns in ~30 ms, but 20 concurrent requests against the
+// same recording each take 9–13 s and a fraction return 500/504. When all N
+// onload handlers then fire in a tight cluster, the main thread is blocked
+// long enough to trip the `health.js-blocked` watchdog (>3 s of synchronous
+// JS), causing the visualizer hang reported in #2461.
+//
+// This module exposes a tiny FIFO-ordered semaphore so each tile preload
+// acquires a slot before issuing its request, with a small in-flight cap.
+// Acquirers wait their turn rather than racing; cancellations (component
+// unmount or `tileSrc` change) free the slot immediately.
+
+const MAX_IN_FLIGHT_TILE_LOADS = 4
+
+let inFlight = 0
+const waiters: Array<(release: () => void) => void> = []
+
+const makeRelease = (): (() => void) => {
+  let released = false
+  return () => {
+    if (released) return
+    released = true
+    inFlight = Math.max(0, inFlight - 1)
+    pump()
+  }
+}
+
+const pump = (): void => {
+  while (inFlight < MAX_IN_FLIGHT_TILE_LOADS && waiters.length > 0) {
+    const next = waiters.shift()
+    if (!next) break
+    inFlight++
+    next(makeRelease())
+  }
+}
+
+/**
+ * Acquire a tile-loader slot. Returns a promise that resolves with a
+ * `release()` callback. Callers MUST invoke `release()` exactly once when
+ * the tile preload settles (load or error) — or earlier, on cancellation,
+ * to let queued tiles proceed.
+ */
+export const acquireTileSlot = async (): Promise<() => void> => {
+  return await new Promise(resolve => {
+    waiters.push(resolve)
+    pump()
+  })
+}
+
+/**
+ * Snapshot of the semaphore state, exposed for tests and debugging.
+ */
+export const tileLoaderState = (): { inFlight: number, waiting: number, max: number } => ({
+  inFlight,
+  waiting: waiters.length,
+  max: MAX_IN_FLIGHT_TILE_LOADS
+})


### PR DESCRIPTION
Promote develop → master.

Single change: #2472 — `fix(visualizer): throttle spectrogram tile preloads to fix #2461 hang`.

This is the actual fix for #2461. The wedge reproduces with `health.js-blocked evalMs=3001–3002` because the visualizer mounts N `<VisualizerTileImg>` in one tick → N synchronous `new Image()` preloads against `/legacy-api/ingest/recordings/*.png` → upstream stream-asset service degrades sharply under concurrency (1 req = 32 ms, 20 concurrent = 9–13 s + 500s) → N onload handlers cluster in a tight burst that blocks the main thread for >3 s.

PR #2472 caps in-flight tile preloads at 4 via a small FIFO semaphore. Frontend-only; no backend changes (those are a separate follow-up).

This unblocks direct-URL navigations to `/p/<slug>/visualizer/rec/<id>` that have been wedging since #2457 deployed.

Verification post-CD will run the standard repro from the bug:

```bash
pkill -9 -f 'Arbimon-Admin'
open /Applications/Arbimon-Admin.app; sleep 6
node implementations/arbimon/admin/cli.js navigate \
  "https://arbimon.org/p/biosoundscape/visualizer/rec/155090002?nocache=$(date +%s)"
sleep 20
node implementations/arbimon/admin/cli.js events tail \
  --kind health.js-blocked --since 30s
```

Expected: zero `health.js-blocked` events.