### PR TITLE
fix(date-input-picker): restore the setDate→changeDate→emit→initialDate guard (#2461)

### DIFF
--- a/apps/website/src/_components/date-range-picker/date-input-picker.vue
+++ b/apps/website/src/_components/date-range-picker/date-input-picker.vue
@@ -161,6 +161,12 @@ onMounted(async () => {
     const dates = picker.value?.getDate()
     if (dates === undefined || dates === null || !(dates instanceof Date)) return
     const dateIso = dayjs(dates).format('YYYY-MM-DD') + 'T00:00:00.000Z'
+    // Defense in depth against the rfcx/arbimon#2461 feedback loop: don't
+    // re-emit `emitSelectDate` when the picker fires `changeDate` with a
+    // value we already published. The setDate guard in `watch(initialDate)`
+    // is the primary fix; this is a belt-and-braces check against any other
+    // future code path that ends up calling `setDate` with the same value.
+    if (dateIso === selectedDateIso.value) return
     selectedDateIso.value = dateIso
     emit('emitSelectDate', { dateLocalIso: dateIso })
   })
@@ -176,8 +182,22 @@ watch(() => props.initialDate, (v) => {
     selectedDateIso.value = ''
   } else {
     const formatted = dayjs(v).format(format)
-    picker.value?.setDate(formatted)
-    if (datePickerInput.value) datePickerInput.value.value = formatted
+    // Guard: only push the new date into the flatpickr instance when it
+    // *actually* differs from what's already displayed. `picker.setDate()`
+    // unconditionally dispatches a `changeDate` event, and the listener
+    // installed below emits `emitSelectDate` to the parent, which mutates
+    // its own `initialDate` ref — which propagates back as `props.initialDate`
+    // to *this* component, re-firing this watcher. Vue 3.3's production
+    // scheduler has no `RECURSION_LIMIT` (see Vue 3.4+'s `checkRecursiveUpdates`
+    // wrapped in a dev-only branch in @vue/runtime-core@3.3.13), so the loop
+    // is unbounded and wedges the renderer thread within ~6 s. Skipping the
+    // setDate when the value is already current breaks the cycle without
+    // changing any user-visible behaviour (the picker is already showing
+    // the right date). See rfcx/arbimon#2461.
+    if (datePickerInput.value?.value !== formatted) {
+      picker.value?.setDate(formatted)
+      if (datePickerInput.value) datePickerInput.value.value = formatted
+    }
     selectedDateIso.value = dayjs(props.initialDate).format('YYYY-MM-DD') + 'T00:00:00.000Z'
   }
 })


### PR DESCRIPTION
Closes #2461 (combined with #2472 + a separate rfcx-local backend fix).

Re-applies the date-input-picker setDate guard from PR #2464 (which was reverted in #2470). The original diagnosis was correct; the fix was reverted because the backend was *also* broken in a way that made it look like the front-end fix didn't help.

## What was actually wrong with #2461

Three independent causes had to all be fixed:

1. **(this PR)** `date-input-picker.vue` had an unbounded synchronous loop: when `visualizer-sidebar` set `initialDate` from the newly-arrived recording's `datetime`, the picker's `setDate()` synchronously fired `changeDate`, which emitted `emitSelectDate` to the parent, which mutated `initialDate` again. Vue 3.3's production scheduler has no recursion guard. This wedged the main thread within ~6 s of the recording-info XHR resolving — that's the `health.js-blocked evalMs=3001` signature.

2. **(merged in #2472)** Once the recording successfully resolves, `<VisualizerSpectrogram>` mounts N `<VisualizerTileImg>` in a single tick, each firing a synchronous `new Image()` preload against `/legacy-api/ingest/recordings/*.png`. That endpoint serialises spectrogram crops per recording upstream and falls over under concurrency. #2472 caps the in-flight tile preloads at 4 via a semaphore.

3. **(rfcx-local; not in this repo)** The `arbimon` legacy-api was leaking spectrogram cache files (a self-defeating `fs.unlink(specFile)` after every tile pass), AND the `TMPFILECACHE_MAXOBJECTLIFETIME=36000` (interpreted as 36 *milliseconds*) Secret from the AWS prod mirror was making every cached file expire in 36 s. The combination meant the `recording-info` XHR took 2–4 s every call and 500'd under any concurrency. Fixed by:
   - `rfcx/arbimon-legacy` PR (separate) — removed the racy `fs.unlink`.
   - `rfcx-local` apps-prod `arbimon-prod-overrides` ConfigMap — overrode `TMPFILECACHE_MAXOBJECTLIFETIME=86400000` and `TMPFILECACHE_CLEANUPINTERVAL=14400000`.
   - `rfcx-local` arbimon deployment — bumped replicas 2→3 for concurrency headroom.

Without (3), no front-end PR could ever pass the standard repro, because the recording-info XHR was either never returning or returning slowly enough to mask whether the post-arrival code path was working.

## Why the cherry-pick is clean

Identical diff to the original 0d530bc73 (verified with `git cherry-pick`). The only change from the reverted version is the commit message, which now explains the *combined* fix landscape.

## Verification

After CD:

```bash
pkill -9 -f 'Arbimon-Admin'
open /Applications/Arbimon-Admin.app; sleep 6
node tools/verify-visualizer.js   # CDP nav + screenshot
```

Expected: page renders normally within ~5s, screenshot shows the spectrogram, no `health.js-blocked` event.

Refs: #2461, restores #2464, complementary to #2472.
