### PR TITLE
Promote develop → master: restore datepicker feedback-loop fix (#2474, completes #2461)

### DIFF
--- a/apps/website/src/_components/date-range-picker/date-input-picker.vue
+++ b/apps/website/src/_components/date-range-picker/date-input-picker.vue
@@ -161,6 +161,12 @@ onMounted(async () => {
     const dates = picker.value?.getDate()
     if (dates === undefined || dates === null || !(dates instanceof Date)) return
     const dateIso = dayjs(dates).format('YYYY-MM-DD') + 'T00:00:00.000Z'
+    // Defense in depth against the rfcx/arbimon#2461 feedback loop: don't
+    // re-emit `emitSelectDate` when the picker fires `changeDate` with a
+    // value we already published. The setDate guard in `watch(initialDate)`
+    // is the primary fix; this is a belt-and-braces check against any other
+    // future code path that ends up calling `setDate` with the same value.
+    if (dateIso === selectedDateIso.value) return
     selectedDateIso.value = dateIso
     emit('emitSelectDate', { dateLocalIso: dateIso })
   })
@@ -176,8 +182,22 @@ watch(() => props.initialDate, (v) => {
     selectedDateIso.value = ''
   } else {
     const formatted = dayjs(v).format(format)
-    picker.value?.setDate(formatted)
-    if (datePickerInput.value) datePickerInput.value.value = formatted
+    // Guard: only push the new date into the flatpickr instance when it
+    // *actually* differs from what's already displayed. `picker.setDate()`
+    // unconditionally dispatches a `changeDate` event, and the listener
+    // installed below emits `emitSelectDate` to the parent, which mutates
+    // its own `initialDate` ref — which propagates back as `props.initialDate`
+    // to *this* component, re-firing this watcher. Vue 3.3's production
+    // scheduler has no `RECURSION_LIMIT` (see Vue 3.4+'s `checkRecursiveUpdates`
+    // wrapped in a dev-only branch in @vue/runtime-core@3.3.13), so the loop
+    // is unbounded and wedges the renderer thread within ~6 s. Skipping the
+    // setDate when the value is already current breaks the cycle without
+    // changing any user-visible behaviour (the picker is already showing
+    // the right date). See rfcx/arbimon#2461.
+    if (datePickerInput.value?.value !== formatted) {
+      picker.value?.setDate(formatted)
+      if (datePickerInput.value) datePickerInput.value.value = formatted
+    }
     selectedDateIso.value = dayjs(props.initialDate).format('YYYY-MM-DD') + 'T00:00:00.000Z'
   }
 })


### PR DESCRIPTION
Promote develop → master.

Single change: #2474 — `fix(date-input-picker): restore the setDate→changeDate→emit→initialDate guard (#2461)`.

This re-applies the cherry of PR #2464 (which was reverted in #2470). The original diagnosis was correct; #2464 was reverted because a backend regression on rfcx-local was masking its effect.

## #2461 summary, end-to-end

Three root causes, all needed to fully resolve:

1. **(merged in #2472)** Tile-load burst: `<VisualizerSpectrogram>` mounts N `<VisualizerTileImg>` synchronously, each fires `new Image()` against `/legacy-api/ingest/recordings/*.png`. Endpoint serialises per-recording, falls over under concurrency. Throttled at 4 concurrent.
2. **(this PR / restored #2464)** Date-input-picker setDate→changeDate→emit→initialDate unbounded sync loop when `visualizer-sidebar` set `initialDate` from the newly-arrived recording's datetime. Vue 3.3's production scheduler has no recursion guard.
3. **(separate, in rfcx-local + arbimon-legacy)** `recording-info` was returning in 2-4 s with 500s under concurrency, because of (a) a self-defeating `fs.unlink(spec.png)` in the legacy-api `fetchSpectrogramTiles` waterfall (race + cache defeat), and (b) the AWS-prod-mirrored `TMPFILECACHE_MAXOBJECTLIFETIME=36000ms` (36 SECONDS) env value. Both fixed; legacy-api now returns sub-100ms on warm hits.

Verification after CD will run the standard wedge repro:

```bash
pkill -9 -f 'Arbimon-Admin'
open /Applications/Arbimon-Admin.app; sleep 6
node tools/verify-visualizer.js
```

Expected: visualizer page renders within 5 s; no `health.js-blocked` event.