### PR TITLE
fix(date-input-picker): suppress changeDate during programmatic setDate (#2461)

### DIFF
--- a/apps/website/src/_components/date-range-picker/date-input-picker.vue
+++ b/apps/website/src/_components/date-range-picker/date-input-picker.vue
@@ -65,6 +65,26 @@ const datePickerInput = ref<HTMLInputElement>()
 const picker = ref<FlowbiteDatePicker>()
 const selectedDateIso = ref('')
 
+// True while a programmatic `picker.setDate(...)` is in progress (from one of
+// our own watchers / `updateViewDate` / `resetDatePicker`). flowbite-datepicker
+// dispatches MULTIPLE `changeDate` events per single `setDate(...)` call when
+// stepping through dates (one per intermediate day; observed up to 5 per call
+// during the rfcx/arbimon#2461 investigation), each with a different
+// `event.detail.date`. The earlier `if (dateIso === selectedDateIso.value)`
+// guard only catches the one whose date matches our target, so the others
+// emit `emitSelectDate` with the intermediate date, the parent assigns it to
+// `initialDate`, this component's watch fires again with the new value, and
+// the cycle compounds. Using a flag to suppress every `changeDate` that
+// originates from a programmatic `setDate` (as opposed to a real user click)
+// is the only reliable way to break the loop without changing behaviour for
+// genuine user interactions.
+let isProgrammaticSetDate = false
+const withProgrammaticSetDate = (fn: () => void): void => {
+  const wasInside = isProgrammaticSetDate
+  isProgrammaticSetDate = true
+  try { fn() } finally { isProgrammaticSetDate = wasInside }
+}
+
 const placeholder = computed(() => props.placeholder ?? 'Choose date')
 const inputLabelFormatted = computed(() => props.inputLabel ?? 'Date')
 const isDisabled = computed(() => props.disabled === true)
@@ -148,7 +168,7 @@ onMounted(async () => {
 
   if (props.initialViewYear != null && props.initialViewMonth != null) {
     const temp = new Date(props.initialViewYear, props.initialViewMonth - 1, 1)
-    picker.value.setDate(temp)
+    withProgrammaticSetDate(() => { picker.value?.setDate(temp) })
   }
 
   if (props.initialDate !== undefined) {
@@ -158,14 +178,16 @@ onMounted(async () => {
   }
 
   datePickerInput.value.addEventListener('changeDate', () => {
+    // Hard suppression: if we're inside our own programmatic setDate, ignore
+    // every changeDate (flowbite-datepicker emits multiple per call). See the
+    // `isProgrammaticSetDate` declaration above for the full rationale.
+    if (isProgrammaticSetDate) return
     const dates = picker.value?.getDate()
     if (dates === undefined || dates === null || !(dates instanceof Date)) return
     const dateIso = dayjs(dates).format('YYYY-MM-DD') + 'T00:00:00.000Z'
     // Defense in depth against the rfcx/arbimon#2461 feedback loop: don't
     // re-emit `emitSelectDate` when the picker fires `changeDate` with a
-    // value we already published. The setDate guard in `watch(initialDate)`
-    // is the primary fix; this is a belt-and-braces check against any other
-    // future code path that ends up calling `setDate` with the same value.
+    // value we already published.
     if (dateIso === selectedDateIso.value) return
     selectedDateIso.value = dateIso
     emit('emitSelectDate', { dateLocalIso: dateIso })
@@ -195,7 +217,7 @@ watch(() => props.initialDate, (v) => {
     // changing any user-visible behaviour (the picker is already showing
     // the right date). See rfcx/arbimon#2461.
     if (datePickerInput.value?.value !== formatted) {
-      picker.value?.setDate(formatted)
+      withProgrammaticSetDate(() => { picker.value?.setDate(formatted) })
       if (datePickerInput.value) datePickerInput.value.value = formatted
     }
     selectedDateIso.value = dayjs(props.initialDate).format('YYYY-MM-DD') + 'T00:00:00.000Z'
@@ -210,7 +232,7 @@ function updateViewDate () {
   const temp = new Date(year, month - 1, 1)
   // do not update the calendar if initialDate was changed it will be processed by watcher for initialDate
   // if (props.initialDate) return
-  picker.value?.setDate(temp)
+  withProgrammaticSetDate(() => { picker.value?.setDate(temp) })
   if (datePickerInput.value) datePickerInput.value.value = ''
   selectedDateIso.value = ''
 }
@@ -229,12 +251,12 @@ watch(() => props.initialViewMonth, () => {
 function resetDatePicker (preset?: { date: string }) {
   if (preset?.date) {
     const formatted = dayjs(preset.date).format(format)
-    picker.value?.setDate(formatted)
+    withProgrammaticSetDate(() => { picker.value?.setDate(formatted) })
     if (datePickerInput.value) datePickerInput.value.value = formatted
     selectedDateIso.value = dayjs(preset.date).format('YYYY-MM-DD') + 'T00:00:00.000Z'
     emit('emitSelectDate', { dateLocalIso: selectedDateIso.value })
   } else {
-    picker.value?.setDate('')
+    withProgrammaticSetDate(() => { picker.value?.setDate('') })
     selectedDateIso.value = ''
     if (datePickerInput.value) datePickerInput.value.value = ''
     emit('emitSelectDate', { dateLocalIso: '' })


### PR DESCRIPTION
Closes #2461.

The setDate guards from #2474 weren't sufficient. CDP instrumentation of the live wedge showed that a single `picker.setDate("16-11-2023")` synchronously dispatches **five** `changeDate` events with progressively earlier dates (`16-11-2023`, `15-11-2023`, `14-11-2023`, `13-11-2023`, `12-11-2023`), because flowbite-datepicker iterates backwards when stepping toward the target.

The previous `if (dateIso === selectedDateIso.value) return` guard catches only the changeDate whose date matches the target. The four intermediate events slip past, each emit `emitSelectDate` with its own intermediate `dateLocalIso`, which the parent assigns to `initialDate`, which re-fires the watcher with the new value, which calls setDate again, which fires five more intermediate dates… the loop compounds at ~30 setDate calls = 150 changeDate events in 50 ms, all dispatching synchronously, blocking the main thread well past 3 s and tripping `health.js-blocked`.

## Repro evidence

```
[3472ms] [SETDATE #1]  args=["16-11-2023"]  input="Invalid Date"
[3473ms] [DISPATCH #1] input.value=16-11-2023  detailDate=2023-11-16T05:00:00.000Z
[3482ms] [DISPATCH #2] input.value=15-11-2023  detailDate=2023-11-15T05:00:00.000Z
[3484ms] [DISPATCH #3] input.value=14-11-2023  detailDate=2023-11-14T05:00:00.000Z
[3485ms] [DISPATCH #4] input.value=13-11-2023  detailDate=2023-11-13T05:00:00.000Z
[3487ms] [DISPATCH #5] input.value=12-11-2023  detailDate=2023-11-12T05:00:00.000Z
[3488ms] [SETDATE #6]  args=["11-11-2023"]  input="12-11-2023"
…
[3513ms] [SETDATE #31] args=["17-10-2023"]  input="18-10-2023"
[3513ms] [SETDATE-LOOP] 31 calls; same caller every time:
  picker.setDate (instrumentation)
  app-e41c095c.js:30:1771    <- watch(initialDate) compiled body
  Ry (Vue callWithErrorHandling)
```

## Fix

Add `isProgrammaticSetDate` boolean flag + a small `withProgrammaticSetDate(fn)` helper that sets it around every internal `setDate` call. The `changeDate` listener early-returns whenever the flag is set, ignoring ALL events from a programmatic setDate (irrespective of how many flowbite chooses to fire) without affecting genuine user clicks.

Wrapped call sites in `date-input-picker.vue`:
- `onMounted` initial `setDate(temp)` (line 171)
- `watch(props.initialDate)` `setDate(formatted)` (line 220)
- `updateViewDate()` `setDate(temp)` (line 235)
- `resetDatePicker()` both branches (`setDate(formatted)` and `setDate('')`)

These are every internal caller. Anything else dispatching changeDate is a real user interaction and behaves identically to before this PR.

## Verification

- `pnpm lint:eslint` on the file: pre-existing warning only (line 164 `any` type, unrelated).
- `vue-tsc --project tsconfig.vuetsc.json --noEmit --skipLibCheck`: clean.
- Local CDP instrumentation against staging: with this change deployed, total setDate calls drops from 100+ to **exactly 1**, no looping changeDate emits. (Will re-verify against the prod bundle after CD.)
- Verification post-CD:
  ```bash
  pkill -9 -f 'Arbimon-Admin'; open /Applications/Arbimon-Admin.app; sleep 6
  node tools/verify-visualizer.js  # navigate + screenshot
  ```
  Expected: visualizer page renders within 5 s, no health.js-blocked event.

## Why the previous fixes were necessary but not sufficient

- **#2472** caps tile preloads at 4 — necessary to prevent the post-render tile burst from being a problem in its own right.
- **#2474** restored #2464's setDate guards — necessary to prevent the simpler case of "setDate fires changeDate with the same date as before" from looping. Insufficient because it only handles the case where the picker fires ONE changeDate per setDate, not the actual flowbite behaviour of firing N.
- **(this PR)** suppresses all changeDate emits during programmatic setDate — the actual loop breaker.

Plus a separate set of rfcx-local backend fixes (faster `recordings/info`, removal of self-defeating spec cache unlink, etc.) which made the wedge observable end-to-end again rather than masked by 30-second XHR timeouts.

Refs #2461, follows #2472, #2474.