### PR TITLE
fix(visualizer): only fetch soundscape regions when in soundscape mode

### DIFF
--- a/apps/website/src/projects/audiodata/visualizer/components/visualizer-spectrogram.vue
+++ b/apps/website/src/projects/audiodata/visualizer/components/visualizer-spectrogram.vue
@@ -649,7 +649,21 @@ const recordingTrainingSetParams = computed<RecordingTrainingSetParams>(() => {
   }
 })
 const { data: trainingSets, refetch: refetchRecordingTrainingSets } = useGetRecordingTrainingSets(apiClientArbimon, selectedProjectSlug, recordingTrainingSetParams)
-const { data: soundscapeRegions } = useGetSoundscapeRegions(apiClientArbimon, selectedProjectSlug, isPlaylist.value ? browserRecId : browserTypeId)
+// `useGetSoundscapeRegions` calls `/legacy-api/project/<slug>/soundscapes/<id>/regions`,
+// which expects a soundscape id, NOT a recording id. The previous call site
+// passed `isPlaylist.value ? browserRecId : browserTypeId`, both of which are
+// recording ids on the `/rec/<id>` and `/playlist/<plId>/<recId>` URL shapes.
+// That meant the request fired on every visualizer page load and got a guaranteed
+// `404 {"error":"soundscape not found"}` (silent to the user because Vue Query has
+// retry:0; visible in network logs and as noise in the backend log).
+//
+// `browserTypeId` IS a soundscape id when `isSoundscape.value === true` (the URL is
+// `/visualizer/soundscape/<soundscapeId>`); we gate on that. Also use a reactive
+// computed so that intra-page browser-type switches (rec <-> soundscape) update
+// correctly — `isPlaylist.value`-read-once in the previous code was not reactive
+// to subsequent route changes either, but fixing that everywhere is out of scope.
+const soundscapeRegionsId = computed(() => isSoundscape.value ? browserTypeId.value : undefined)
+const { data: soundscapeRegions } = useGetSoundscapeRegions(apiClientArbimon, selectedProjectSlug, soundscapeRegionsId)
 
 const legendMetrics = computed(() => {
   return {


### PR DESCRIPTION
Found during a read-only recon of the SPA after #2461 was closed. Every visualizer page load on a `/rec/<id>` or `/playlist/<plId>/<recId>` URL fires a request to `/legacy-api/project/<slug>/soundscapes/<id>/regions?view=tags` and gets a guaranteed `404 {"error":"soundscape not found"}` back. The backend is correct; the frontend was passing a recording id where a soundscape id is expected.

## What was wrong

`visualizer-spectrogram.vue` line 652:

```ts
const { data: soundscapeRegions } = useGetSoundscapeRegions(
  apiClientArbimon,
  selectedProjectSlug,
  isPlaylist.value ? browserRecId : browserTypeId,
)
```

The composable parameter is named `soundscapeId` and the endpoint pattern is `/soundscapes/<soundscapeId>/regions`. But `browserTypeId` / `browserRecId` are only soundscape ids when `browserType === 'soundscape'`:

| URL shape                                  | browserType    | browserTypeId    | browserRecId   |
|--------------------------------------------|----------------|------------------|----------------|
| `visualizer/rec/<recId>`                   | `'rec'`        | recId            | undefined      |
| `visualizer/playlist/<plId>/<recId>`       | `'playlist'`   | playlistId       | recId          |
| `visualizer/soundscape/<soundscapeId>`     | `'soundscape'` | **soundscapeId** | undefined      |

So the ternary picked the wrong key on every non-soundscape page → guaranteed 404. Vue Query's `retry: 0` swallows the error from the user, but it shows up in every prod request log and clutters network traces. (This was one of the noise sources that made the #2461 investigation noisier than it needed to be.)

## Reproduction

```
curl -H "Authorization: Bearer <token>" \
  https://arbimon.org/legacy-api/project/biosoundscape/soundscapes/155090002/regions?view=tags
# → 404 {"error":"soundscape not found"}
```

`155090002` is a recording id; the endpoint correctly rejects it.

## Fix

```ts
const soundscapeRegionsId = computed(() =>
  isSoundscape.value ? browserTypeId.value : undefined
)
const { data: soundscapeRegions } = useGetSoundscapeRegions(
  apiClientArbimon, selectedProjectSlug, soundscapeRegionsId
)
```

The composable already returns `[]` from the queryFn when the id is undefined, so no extra wiring needed. The downstream `watch(soundscapeRegions.value)` early-returns on undefined.

## Why a reactive `computed` (not `isSoundscape.value` read once)

`isPlaylist.value`-read-once-at-setup was its own bug — it didn't update when the browser-type changed intra-page. The pattern is pervasive across the file though, so fixing it everywhere is out of scope. This change uses `isSoundscape.value` *reactively* inside a `computed`, which is the right pattern; matching it elsewhere can be a separate cleanup.

## Verification

- `pnpm lint:eslint` on the file: pre-existing warning only (line 810 `any` type, unrelated to this diff).
- `vue-tsc --project tsconfig.vuetsc.json --noEmit --skipLibCheck`: clean.
- After CD: on `/visualizer/rec/<recId>` URLs the `/soundscapes/.../regions` request will no longer fire (skipped by the composable when the id is undefined). On `/visualizer/soundscape/<soundscapeId>` it fires with the correct id, behaving the same as before for the only case where it actually worked.

Refs #2461 (one of the noise sources during investigation).