### PR TITLE
Promote develop → master: fix visualizer soundscape-regions 404 (#2478) + CD trigger hygiene (#2460)

### DIFF
--- a/.github/workflows/cd.yaml
+++ b/.github/workflows/cd.yaml
@@ -17,7 +17,13 @@ on:
   push:
     branches:
       - master
-      - staging
+      # NOTE: 'staging' was removed from this list 2026-05-19. The current
+      # `Deploy: rfcx-local` job is gated to namespace=='production' (master
+      # only), so push to staging triggered the workflow but skipped every
+      # deploy step. Until a real staging environment is provisioned in
+      # rfcx-local (apps-staging namespace + staging.arbimon.org ingress),
+      # CD on staging is a no-op and only confused contributors. See
+      # rfcx-local STATE.md / runbooks for the planned staging environment.
 concurrency: ${{ github.workflow }}-${{ github.ref }}
 jobs:  
   configure:

--- a/apps/website/src/projects/audiodata/visualizer/components/visualizer-spectrogram.vue
+++ b/apps/website/src/projects/audiodata/visualizer/components/visualizer-spectrogram.vue
@@ -649,7 +649,21 @@ const recordingTrainingSetParams = computed<RecordingTrainingSetParams>(() => {
   }
 })
 const { data: trainingSets, refetch: refetchRecordingTrainingSets } = useGetRecordingTrainingSets(apiClientArbimon, selectedProjectSlug, recordingTrainingSetParams)
-const { data: soundscapeRegions } = useGetSoundscapeRegions(apiClientArbimon, selectedProjectSlug, isPlaylist.value ? browserRecId : browserTypeId)
+// `useGetSoundscapeRegions` calls `/legacy-api/project/<slug>/soundscapes/<id>/regions`,
+// which expects a soundscape id, NOT a recording id. The previous call site
+// passed `isPlaylist.value ? browserRecId : browserTypeId`, both of which are
+// recording ids on the `/rec/<id>` and `/playlist/<plId>/<recId>` URL shapes.
+// That meant the request fired on every visualizer page load and got a guaranteed
+// `404 {"error":"soundscape not found"}` (silent to the user because Vue Query has
+// retry:0; visible in network logs and as noise in the backend log).
+//
+// `browserTypeId` IS a soundscape id when `isSoundscape.value === true` (the URL is
+// `/visualizer/soundscape/<soundscapeId>`); we gate on that. Also use a reactive
+// computed so that intra-page browser-type switches (rec <-> soundscape) update
+// correctly — `isPlaylist.value`-read-once in the previous code was not reactive
+// to subsequent route changes either, but fixing that everywhere is out of scope.
+const soundscapeRegionsId = computed(() => isSoundscape.value ? browserTypeId.value : undefined)
+const { data: soundscapeRegions } = useGetSoundscapeRegions(apiClientArbimon, selectedProjectSlug, soundscapeRegionsId)
 
 const legendMetrics = computed(() => {
   return {


### PR DESCRIPTION
Promote develop → master.

Two changes:

- **#2478** — `fix(visualizer): only fetch soundscape regions when in soundscape mode`. Gates `useGetSoundscapeRegions` on `isSoundscape` reactively, eliminating a guaranteed `404 {"error":"soundscape not found"}` request that fires on every `/visualizer/rec/<id>` and `/visualizer/playlist/.../...` page load. Found during read-only SPA recon after #2461 was closed.

- **#2460** — `ci(cd): drop no-op 'staging' push trigger from cd.yaml`. CI hygiene: removes a no-op CD trigger so staging pushes don't fire empty workflow runs + misleading Slack notifications.

Both are low-risk; neither changes user-visible behaviour, both reduce noise.