### PR TITLE
fix(api+website): super-user bypass on getProjectBySlug + auth-aware refetch

### DIFF
--- a/apps/api/src/_services/auth0/is-super-user.ts
+++ b/apps/api/src/_services/auth0/is-super-user.ts
@@ -1,0 +1,23 @@
+import { type FastifyRequest } from 'fastify'
+
+import { env } from '~/env'
+
+/**
+ * Returns true iff the authenticated request was made by an account
+ * whose Auth0 email is listed in the `SUPER_USER_EMAILS` env var
+ * (comma-separated).
+ *
+ * This is the same allow-list used by `require-super.ts` for /super/*
+ * routes. Use this helper anywhere the bio-api needs to short-circuit
+ * a per-project membership check for an org-level super user (e.g.
+ * support staff viewing a hidden project to triage a ticket).
+ *
+ * Returns false if there is no Authorization header, the token has
+ * no email claim, or the email is not on the allow-list.
+ */
+export const isSuperUser = (req: FastifyRequest): boolean => {
+  const email = req.userToken?.email
+  if (email === undefined) return false
+  const superUserEmails = env.SUPER_USER_EMAILS !== undefined && env.SUPER_USER_EMAILS !== '' ? env.SUPER_USER_EMAILS.split(',') : []
+  return superUserEmails.includes(email)
+}

--- a/apps/api/src/_services/auth0/is-super-user.unit.test.ts
+++ b/apps/api/src/_services/auth0/is-super-user.unit.test.ts
@@ -1,0 +1,43 @@
+import { type FastifyRequest } from 'fastify'
+import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest'
+
+vi.mock('~/env', () => ({ env: { SUPER_USER_EMAILS: '' } }))
+
+const makeReq = (email?: string): FastifyRequest =>
+  ({ userToken: email === undefined ? null : { email, idAuth0: 'auth0|x', firstName: '', lastName: '' } } as unknown as FastifyRequest)
+
+describe('isSuperUser', () => {
+  let env: { SUPER_USER_EMAILS?: string }
+  let isSuperUser: (req: FastifyRequest) => boolean
+
+  beforeEach(async () => {
+    vi.resetModules()
+    ;({ env } = await import('~/env'))
+    ;({ isSuperUser } = await import('./is-super-user'))
+    env.SUPER_USER_EMAILS = 'support@rfcx.org,scientist-super@rfcx.org'
+  })
+
+  afterEach(() => { env.SUPER_USER_EMAILS = '' })
+
+  test('returns true when token email is on the allow-list', () => {
+    expect(isSuperUser(makeReq('support@rfcx.org'))).toBe(true)
+    expect(isSuperUser(makeReq('scientist-super@rfcx.org'))).toBe(true)
+  })
+
+  test('returns false when token email is not on the allow-list', () => {
+    expect(isSuperUser(makeReq('cathcollins89@gmail.com'))).toBe(false)
+  })
+
+  test('returns false when no Authorization / no token', () => {
+    expect(isSuperUser(makeReq(undefined))).toBe(false)
+  })
+
+  test('returns false when SUPER_USER_EMAILS env is empty', () => {
+    env.SUPER_USER_EMAILS = ''
+    expect(isSuperUser(makeReq('support@rfcx.org'))).toBe(false)
+  })
+
+  test('is case-sensitive (matches how require-super.ts compares)', () => {
+    expect(isSuperUser(makeReq('SUPPORT@rfcx.org'))).toBe(false)
+  })
+})

--- a/apps/api/src/projects/projects-bll.ts
+++ b/apps/api/src/projects/projects-bll.ts
@@ -33,11 +33,20 @@ export const getProjectsGeo = async (limit?: number, offset?: number): Promise<P
   return projects
 }
 
-export const getProjectBySlugForUser = async (slug: string, userId: number | undefined): Promise<LocationProjectWithRole> => {
+export const getProjectBySlugForUser = async (slug: string, userId: number | undefined, isSuper: boolean = false): Promise<LocationProjectWithRole> => {
   const project = await getProjectBySlug(slug)
   if (project === undefined) { throw BioNotFoundError() }
 
-  const role = await getUserRoleForProject(userId, project.id)
+  let role = await getUserRoleForProject(userId, project.id)
+  // Super-user bypass: org-level support/scientist accounts (allow-list in
+  // SUPER_USER_EMAILS) are escalated to 'admin' on any project they aren't
+  // an explicit member of. Mirrors the legacy arbimon `is_super` behaviour
+  // (where the legacy app treats super users as admins on every project) so
+  // support staff can triage tickets against hidden / unlisted projects.
+  // We deliberately escalate to 'admin' rather than 'owner' so that
+  // owner-only operations (e.g. project deletion) still require an actual
+  // owner membership row.
+  if (role === 'none' && isSuper) { role = 'admin' }
   if (role === 'none') { throw BioNotFoundError() }
 
   const usage = await getProjectTieringUsage(project.id)

--- a/apps/api/src/projects/projects-handler.ts
+++ b/apps/api/src/projects/projects-handler.ts
@@ -1,5 +1,6 @@
 import { type LocationProjectQuery, type LocationProjectWithRole, type MyProjectsResponse, type ProjectsGeoResponse } from '@rfcx-bio/common/api-bio/project/projects'
 
+import { isSuperUser } from '@/_services/auth0/is-super-user'
 import { type Handler } from '../_services/api-helpers/types'
 import { getMyProjectsWithInfo, getViewableProjects } from './dao/projects-dao'
 import { getProjectBySlugForUser, getProjectsGeo } from './projects-bll'
@@ -18,5 +19,5 @@ export const myProjectsHandler: Handler<MyProjectsResponse, unknown, LocationPro
 
 export const getProjectBySlugHandler: Handler<LocationProjectWithRole, { slug: string }, unknown, unknown> = async (req) => {
   const userId = req.userId
-  return await getProjectBySlugForUser(req.params.slug, userId)
+  return await getProjectBySlugForUser(req.params.slug, userId, isSuperUser(req))
 }

--- a/apps/website/src/_services/store/index.ts
+++ b/apps/website/src/_services/store/index.ts
@@ -68,8 +68,41 @@ export const useStore = defineStore('root', {
     async updateSelectedProjectSlug (slug: string) {
       // Temporary hack to get an API Client (this will be extracted in the loading branch)
       const authClient = await useAuth0Client()
-      const apiClient = getApiClient(import.meta.env.VITE_API_BASE_URL, this.user ? async () => await getIdToken(authClient) : undefined)
+      // Always attach a token-resolver: even when `this.user` is undefined,
+      // the Auth0 SDK may still resolve a token via the existing SSO
+      // session (the user simply hadn't called `getUser()` yet, or the
+      // pinia state was hydrated before the auth bootstrap finished).
+      // If `getIdToken` throws (no SSO, login_required, etc.) the request
+      // falls back to an anonymous call — same behaviour as before for
+      // truly logged-out visitors.
+      //
+      // Why this matters: on direct-URL navigation to a non-public
+      // project (`status='hidden'|'unlisted'`), an anonymous fetch returns
+      // 404 from the bio-api, which renders the "This project either does
+      // not exist…" page even when the visitor actually has an Auth0
+      // session and is a member of the project (2026-05-27 support ticket
+      // for `asian-short-clawed-otters-in-plankendael-zoo`).
+      const getToken = async (): Promise<string> => {
+        try {
+          return await getIdToken(authClient)
+        } catch {
+          return ''
+        }
+      }
+      const apiClient = getApiClient(import.meta.env.VITE_API_BASE_URL, getToken)
       this.project = await apiBioGetProjectBySlug(apiClient, slug)
+      // If we got nothing AND we previously thought we had no user, try
+      // refreshing the user state once — `getTokenSilently` may have
+      // populated the SDK's user cache on the previous call.
+      if (this.project === undefined && this.user === undefined) {
+        try {
+          const refreshedUser = await authClient.getUser()
+          if (refreshedUser !== undefined) {
+            this.user = refreshedUser
+            this.project = await apiBioGetProjectBySlug(apiClient, slug)
+          }
+        } catch { /* ignore */ }
+      }
     },
     updateSelectedProject (project?: LocationProjectWithRole) {
       if (this.project?.id === project?.id) return

--- a/packages/utils/src/api/api-client.ts
+++ b/packages/utils/src/api/api-client.ts
@@ -9,8 +9,15 @@ export const getApiClient = (baseURL: string, getToken?: () => Promise<string>):
 
   if (getToken !== undefined) {
     apiClient.interceptors.request.use(async config => {
+      // `getToken` may return an empty string when the caller wanted to
+      // try an authenticated request opportunistically but the SDK had
+      // no SSO session to draw on. Skip the Authorization header in that
+      // case rather than sending `Bearer ` (which the bio-api treats as
+      // an invalid token).
       const token = await getToken()
-      config.headers = { ...config.headers, Authorization: `Bearer ${token}` }
+      if (token) {
+        config.headers = { ...config.headers, Authorization: `Bearer ${token}` }
+      }
       return config
     })
 


### PR DESCRIPTION
## Summary

Two interrelated bugs surfaced by a **2026-05-27 support ticket** for project `asian-short-clawed-otters-in-plankendael-zoo` (`location_project.id=1161909`, `status='hidden'`). The project owner (cathcollins89@gmail.com) and support@rfcx.org both saw the "This project either does not exist or you do not have permission to access it" screen.

DB state was fully intact (cathy has `role_id=4` Owner on this project in `insights.location_project_user_role`; the project has 1 site + 174 recordings in `arbimon2`). Two latent bugs combined to make it look broken.

## (B) Super-user bypass on `getProjectBySlugForUser`

`getUserRoleForProject` returns `'none'` for any non-member of a hidden/unlisted project (it only falls back to `'external'` when `status='published'`). The `/super/*` routes have a `SUPER_USER_EMAILS` allow-list (`require-super.ts`), but the per-project endpoints had no equivalent bypass, so a super user like `support@rfcx.org` couldn't fetch a hidden project on which they weren't an explicit member. **This diverges from legacy arbimon's `is_super` behaviour**, where super users are treated as admin on every project.

- New helper `apps/api/src/_services/auth0/is-super-user.ts` reuses the same `SUPER_USER_EMAILS` env-driven allow-list.
- BLL `getProjectBySlugForUser` accepts an `isSuper` flag and escalates a `'none'` role to `'admin'` (not `'owner'` — `delete-project` still requires an explicit owner row).
- Handler passes `isSuperUser(req)`.
- New vitest unit test covers allow-list match / non-match / missing token / empty env / case sensitivity (5 cases, all green).

## (C) Frontend auth-aware refetch on direct-URL project navigation

`apps/website` `store.updateSelectedProjectSlug` was constructing the api-client with `this.user ? getIdToken : undefined`. When pinia state hadn't been populated by Auth0 bootstrap (direct URL navigation, refresh, or restored SSR state hydrating before auth), the project fetch went out anonymously and bio-api 404'd hidden projects, leaving `store.project=undefined` — which renders the generic invalid-project screen even when the visitor actually has an Auth0 SSO session and is a member.

- Always pass a `getToken` resolver that tries `getIdToken` in a try/catch (returns `''` on failure).
- `api-client` interceptor (`packages/utils`) now skips the `Authorization` header on empty-string tokens — avoids sending `Bearer ` (which the bio-api would reject). Guests keep working unchanged.
- Belt-and-braces: if the first fetch returns `undefined` AND `this.user` was still `undefined`, refresh the user via `authClient.getUser()` and retry once (the first `getIdToken` call will have populated the SDK's user cache).

## Compatibility / risk

- B is additive: only escalates `'none' → 'admin'` for emails on the existing `SUPER_USER_EMAILS` allow-list. No existing role resolution path changes for non-super accounts. Live production env already has `SUPER_USER_EMAILS=support@rfcx.org,scientist-super@rfcx.org`.
- C: `api-client` now skips the header on empty tokens. The only callers passing a `getToken` function are `apps/website/src/main.ts` factories and the store fetcher; both currently rely on `getIdToken` throwing rather than returning empty, so existing behaviour is preserved for them.
- All `apps/api` lint + build + unit tests pass.
- `apps/website` + `packages/utils` lint clean (no new warnings).
- `packages/utils` build clean.

## Verification on rfcx-local before this PR

To unblock the ticket immediately I added support@rfcx.org as Admin on location_project 1161909 in the rfcx-local insights DB:
```sql
INSERT INTO insights.location_project_user_role
  (location_project_id, user_id, role_id, ranking, created_at, updated_at)
VALUES (1161909, 39, 1, -1, NOW(), NOW());
```
Page-reload as support@ then returned HTTP 200 with role:'admin', and the project overview renders fully (1 site, 174 recordings, 1 species, Plankendael map marker — verified via standalone-browser screenshot).

Once this PR ships, that one-off INSERT is redundant — support@rfcx.org will be escalated to admin on every project by the new bypass code path.

## Files touched

- `apps/api/src/_services/auth0/is-super-user.ts` (new)
- `apps/api/src/_services/auth0/is-super-user.unit.test.ts` (new, 5 tests)
- `apps/api/src/projects/projects-bll.ts` (`getProjectBySlugForUser` accepts `isSuper` flag)
- `apps/api/src/projects/projects-handler.ts` (passes `isSuperUser(req)`)
- `apps/website/src/_services/store/index.ts` (auth-aware fetch + retry)
- `packages/utils/src/api/api-client.ts` (skip header on empty token)
