### PR TITLE
Promote: staging → master (super-bypass + auth-aware refetch)

### DIFF
--- a/apps/api/src/_services/auth0/is-super-user.ts
+++ b/apps/api/src/_services/auth0/is-super-user.ts
@@ -1,0 +1,23 @@
+import { type FastifyRequest } from 'fastify'
+
+import { env } from '~/env'
+
+/**
+ * Returns true iff the authenticated request was made by an account
+ * whose Auth0 email is listed in the `SUPER_USER_EMAILS` env var
+ * (comma-separated).
+ *
+ * This is the same allow-list used by `require-super.ts` for /super/*
+ * routes. Use this helper anywhere the bio-api needs to short-circuit
+ * a per-project membership check for an org-level super user (e.g.
+ * support staff viewing a hidden project to triage a ticket).
+ *
+ * Returns false if there is no Authorization header, the token has
+ * no email claim, or the email is not on the allow-list.
+ */
+export const isSuperUser = (req: FastifyRequest): boolean => {
+  const email = req.userToken?.email
+  if (email === undefined) return false
+  const superUserEmails = env.SUPER_USER_EMAILS !== undefined && env.SUPER_USER_EMAILS !== '' ? env.SUPER_USER_EMAILS.split(',') : []
+  return superUserEmails.includes(email)
+}

--- a/apps/api/src/_services/auth0/is-super-user.unit.test.ts
+++ b/apps/api/src/_services/auth0/is-super-user.unit.test.ts
@@ -1,0 +1,43 @@
+import { type FastifyRequest } from 'fastify'
+import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest'
+
+vi.mock('~/env', () => ({ env: { SUPER_USER_EMAILS: '' } }))
+
+const makeReq = (email?: string): FastifyRequest =>
+  ({ userToken: email === undefined ? null : { email, idAuth0: 'auth0|x', firstName: '', lastName: '' } } as unknown as FastifyRequest)
+
+describe('isSuperUser', () => {
+  let env: { SUPER_USER_EMAILS?: string }
+  let isSuperUser: (req: FastifyRequest) => boolean
+
+  beforeEach(async () => {
+    vi.resetModules()
+    ;({ env } = await import('~/env'))
+    ;({ isSuperUser } = await import('./is-super-user'))
+    env.SUPER_USER_EMAILS = 'support@rfcx.org,scientist-super@rfcx.org'
+  })
+
+  afterEach(() => { env.SUPER_USER_EMAILS = '' })
+
+  test('returns true when token email is on the allow-list', () => {
+    expect(isSuperUser(makeReq('support@rfcx.org'))).toBe(true)
+    expect(isSuperUser(makeReq('scientist-super@rfcx.org'))).toBe(true)
+  })
+
+  test('returns false when token email is not on the allow-list', () => {
+    expect(isSuperUser(makeReq('cathcollins89@gmail.com'))).toBe(false)
+  })
+
+  test('returns false when no Authorization / no token', () => {
+    expect(isSuperUser(makeReq(undefined))).toBe(false)
+  })
+
+  test('returns false when SUPER_USER_EMAILS env is empty', () => {
+    env.SUPER_USER_EMAILS = ''
+    expect(isSuperUser(makeReq('support@rfcx.org'))).toBe(false)
+  })
+
+  test('is case-sensitive (matches how require-super.ts compares)', () => {
+    expect(isSuperUser(makeReq('SUPPORT@rfcx.org'))).toBe(false)
+  })
+})

--- a/apps/api/src/projects/projects-bll.ts
+++ b/apps/api/src/projects/projects-bll.ts
@@ -33,11 +33,20 @@ export const getProjectsGeo = async (limit?: number, offset?: number): Promise<P
   return projects
 }
 
-export const getProjectBySlugForUser = async (slug: string, userId: number | undefined): Promise<LocationProjectWithRole> => {
+export const getProjectBySlugForUser = async (slug: string, userId: number | undefined, isSuper: boolean = false): Promise<LocationProjectWithRole> => {
   const project = await getProjectBySlug(slug)
   if (project === undefined) { throw BioNotFoundError() }
 
-  const role = await getUserRoleForProject(userId, project.id)
+  let role = await getUserRoleForProject(userId, project.id)
+  // Super-user bypass: org-level support/scientist accounts (allow-list in
+  // SUPER_USER_EMAILS) are escalated to 'admin' on any project they aren't
+  // an explicit member of. Mirrors the legacy arbimon `is_super` behaviour
+  // (where the legacy app treats super users as admins on every project) so
+  // support staff can triage tickets against hidden / unlisted projects.
+  // We deliberately escalate to 'admin' rather than 'owner' so that
+  // owner-only operations (e.g. project deletion) still require an actual
+  // owner membership row.
+  if (role === 'none' && isSuper) { role = 'admin' }
   if (role === 'none') { throw BioNotFoundError() }
 
   const usage = await getProjectTieringUsage(project.id)

--- a/apps/api/src/projects/projects-handler.ts
+++ b/apps/api/src/projects/projects-handler.ts
@@ -1,5 +1,6 @@
 import { type LocationProjectQuery, type LocationProjectWithRole, type MyProjectsResponse, type ProjectsGeoResponse } from '@rfcx-bio/common/api-bio/project/projects'
 
+import { isSuperUser } from '@/_services/auth0/is-super-user'
 import { type Handler } from '../_services/api-helpers/types'
 import { getMyProjectsWithInfo, getViewableProjects } from './dao/projects-dao'
 import { getProjectBySlugForUser, getProjectsGeo } from './projects-bll'
@@ -18,5 +19,5 @@ export const myProjectsHandler: Handler<MyProjectsResponse, unknown, LocationPro
 
 export const getProjectBySlugHandler: Handler<LocationProjectWithRole, { slug: string }, unknown, unknown> = async (req) => {
   const userId = req.userId
-  return await getProjectBySlugForUser(req.params.slug, userId)
+  return await getProjectBySlugForUser(req.params.slug, userId, isSuperUser(req))
 }

--- a/apps/website/src/_services/store/index.ts
+++ b/apps/website/src/_services/store/index.ts
@@ -68,8 +68,41 @@ export const useStore = defineStore('root', {
     async updateSelectedProjectSlug (slug: string) {
       // Temporary hack to get an API Client (this will be extracted in the loading branch)
       const authClient = await useAuth0Client()
-      const apiClient = getApiClient(import.meta.env.VITE_API_BASE_URL, this.user ? async () => await getIdToken(authClient) : undefined)
+      // Always attach a token-resolver: even when `this.user` is undefined,
+      // the Auth0 SDK may still resolve a token via the existing SSO
+      // session (the user simply hadn't called `getUser()` yet, or the
+      // pinia state was hydrated before the auth bootstrap finished).
+      // If `getIdToken` throws (no SSO, login_required, etc.) the request
+      // falls back to an anonymous call — same behaviour as before for
+      // truly logged-out visitors.
+      //
+      // Why this matters: on direct-URL navigation to a non-public
+      // project (`status='hidden'|'unlisted'`), an anonymous fetch returns
+      // 404 from the bio-api, which renders the "This project either does
+      // not exist…" page even when the visitor actually has an Auth0
+      // session and is a member of the project (2026-05-27 support ticket
+      // for `asian-short-clawed-otters-in-plankendael-zoo`).
+      const getToken = async (): Promise<string> => {
+        try {
+          return await getIdToken(authClient)
+        } catch {
+          return ''
+        }
+      }
+      const apiClient = getApiClient(import.meta.env.VITE_API_BASE_URL, getToken)
       this.project = await apiBioGetProjectBySlug(apiClient, slug)
+      // If we got nothing AND we previously thought we had no user, try
+      // refreshing the user state once — `getTokenSilently` may have
+      // populated the SDK's user cache on the previous call.
+      if (this.project === undefined && this.user === undefined) {
+        try {
+          const refreshedUser = await authClient.getUser()
+          if (refreshedUser !== undefined) {
+            this.user = refreshedUser
+            this.project = await apiBioGetProjectBySlug(apiClient, slug)
+          }
+        } catch { /* ignore */ }
+      }
     },
     updateSelectedProject (project?: LocationProjectWithRole) {
       if (this.project?.id === project?.id) return

--- a/packages/utils/src/api/api-client.ts
+++ b/packages/utils/src/api/api-client.ts
@@ -9,8 +9,15 @@ export const getApiClient = (baseURL: string, getToken?: () => Promise<string>):
 
   if (getToken !== undefined) {
     apiClient.interceptors.request.use(async config => {
+      // `getToken` may return an empty string when the caller wanted to
+      // try an authenticated request opportunistically but the SDK had
+      // no SSO session to draw on. Skip the Authorization header in that
+      // case rather than sending `Bearer ` (which the bio-api treats as
+      // an invalid token).
       const token = await getToken()
-      config.headers = { ...config.headers, Authorization: `Bearer ${token}` }
+      if (token) {
+        config.headers = { ...config.headers, Authorization: `Bearer ${token}` }
+      }
       return config
     })
 


### PR DESCRIPTION
Ships #2480 to rfcx-local prod via the master-push CD pipeline.