### PR TITLE
fix(cli): send descriptive User-Agent to Wikimedia APIs

### DIFF
--- a/apps/cli/src/ingest/_refactor/input-wiki/get-wiki-image-info.ts
+++ b/apps/cli/src/ingest/_refactor/input-wiki/get-wiki-image-info.ts
@@ -2,6 +2,7 @@ import axios, { type AxiosRequestConfig } from 'axios'
 
 import { logError } from '~/axios'
 import { requireEnv } from '~/env'
+import { WIKI_USER_AGENT } from './user-agent'
 
 export interface WikiMediaImageInfo {
   descriptionurl: string
@@ -26,7 +27,10 @@ export async function getWikiImageInfo (fileName: string | undefined): Promise<W
   if (!fileName) return undefined
   const endpoint: AxiosRequestConfig = {
     method: 'GET',
-    url: `${WIKI_MEDIA_BASE_URL}/w/api.php?action=query&prop=imageinfo&iiprop=extmetadata|url&format=json&titles=File:${fileName}`
+    url: `${WIKI_MEDIA_BASE_URL}/w/api.php?action=query&prop=imageinfo&iiprop=extmetadata|url&format=json&titles=File:${fileName}`,
+    headers: {
+      'User-Agent': WIKI_USER_AGENT
+    }
   }
 
   return await axios.request<WikiMediaResponse>(endpoint)

--- a/apps/cli/src/ingest/_refactor/input-wiki/get-wiki-species.ts
+++ b/apps/cli/src/ingest/_refactor/input-wiki/get-wiki-species.ts
@@ -2,6 +2,7 @@ import axios, { type AxiosRequestConfig } from 'axios'
 
 import { logError } from '~/axios'
 import { requireEnv } from '~/env'
+import { WIKI_USER_AGENT } from './user-agent'
 
 export interface WikiSummaryResponse {
   type: string
@@ -59,7 +60,10 @@ const { WIKI_BASE_URL } = requireEnv('WIKI_BASE_URL')
 export async function getWikiSpecies (scientificName: string): Promise<WikiSummaryResponse | undefined> {
   const endpoint: AxiosRequestConfig = {
     method: 'GET',
-    url: `${WIKI_BASE_URL}/api/rest_v1/page/summary/${scientificName}`
+    url: `${WIKI_BASE_URL}/api/rest_v1/page/summary/${scientificName}`,
+    headers: {
+      'User-Agent': WIKI_USER_AGENT
+    }
   }
 
   return await axios.request<WikiSummaryResponse>(endpoint)

--- a/apps/cli/src/ingest/_refactor/input-wiki/user-agent.ts
+++ b/apps/cli/src/ingest/_refactor/input-wiki/user-agent.ts
@@ -1,0 +1,7 @@
+// Wikimedia's API Policy (see https://phabricator.wikimedia.org/T400119 and
+// https://meta.wikimedia.org/wiki/User-Agent_policy) requires every API client
+// to send a descriptive User-Agent that identifies the application and a way
+// to contact the operator. Anonymous / generic UAs (including axios's default
+// `axios/<version>`) are now blocked with HTTP 403, which breaks the daily
+// Wiki species sync. Keep this string descriptive and include contact info.
+export const WIKI_USER_AGENT = 'BiodiversityCLI/1.0 (https://github.com/rfcx/arbimon; support@rfcx.org)'


### PR DESCRIPTION
## Why

The daily `biodiversity-cli-sync-daily` CronJob has been failing in staging/production. Wikimedia is now refusing the axios default User-Agent (`axios/<version>`) with HTTP 403:

> Please set a user-agent and respect our robot policy https://w.wiki/4wJS. See also https://phabricator.wikimedia.org/T400119.

This enforces the long-standing Wikimedia User-Agent policy, formalized in the [2024 API Policy update](https://meta.wikimedia.org/wiki/User-Agent_policy). Generic / library-default UAs are now blocked.

Every `getWikiSummary` call was silently swallowed by `logError`, which left `taxon_species_wiki` perpetually un-refreshed and stretched the job long enough to trip the kubectl wait (`timed out waiting for the condition` in the cron run).

## What

- Add `WIKI_USER_AGENT` constant: `BiodiversityCLI/1.0 (https://github.com/rfcx/arbimon; support@rfcx.org)` (descriptive, includes contact info as the policy requires).
- Send it as the `User-Agent` header on:
  - `getWikiSpecies` → `{WIKI_BASE_URL}/api/rest_v1/page/summary/...`
  - `getWikiImageInfo` → `{WIKI_MEDIA_BASE_URL}/w/api.php?action=query&prop=imageinfo...`

No other behavior change.

## Verification

Live smoke test:

| Request | Status |
|---|---|
| Default axios UA → `page/summary/Panthera_leo` | **403** (reproduces the failure) |
| New UA → `page/summary/Panthera leo` | 200, title=`Lion` |
| New UA → `page/summary/Tyto alba` | 200, title=`Western barn owl` |
| New UA → `page/summary/Bogusmalogus_xyz_not_real` | 404 (expected, handled) |
| New UA → `imageinfo File:Barn_Owl,_Lancashire.jpg` | 200, license=`CC BY 2.0` |

Build (`pnpm build`) and `eslint` on the touched files pass.

## Refs
- https://phabricator.wikimedia.org/T400119
- https://meta.wikimedia.org/wiki/User-Agent_policy