### PR TITLE
Remove Danger Zone section and Request backup button from Project settings

### DIFF
--- a/apps/website/src/projects/components/project-backup/project-backup.vue
+++ b/apps/website/src/projects/components/project-backup/project-backup.vue
@@ -22,15 +22,6 @@
         >
           This project is currently view-only and cannot request exports or backups.
         </div>
-        <a
-          type="button"
-          href="mailto:jon@rfcx.org"
-          class="rounded-full h-10 text-pitch font-medium bg-frequency w-fit mt-6 px-5 py-3 text-center hover:bg-chirp flex flex-row items-center"
-          data-tooltip-target="Backuptooltip"
-          data-tooltip-style="light"
-        >
-          Request backup
-        </a>
         <div class="text-flamingo mt-3">
           To request a full backup of this project, please send an email to jon@rfcx.org
         </div>

--- a/apps/website/src/projects/project-settings-page.vue
+++ b/apps/website/src/projects/project-settings-page.vue
@@ -117,14 +117,6 @@
             <hr class="border-util-gray-03 my-6">
             <project-backup />
           </template>
-          <hr class="border-util-gray-03 my-6">
-          <project-delete
-            v-if="store.project?.role === 'owner' && store.project?.isLocked !== true"
-            :is-deleting="isDeletingProject"
-            :is-error="isErrorDeleteProject"
-            :is-success="isSuccessDeleteProject"
-            @emit-project-delete="onEmitProjectDelete"
-          />
         </div>
       </div>
     </div>
@@ -135,7 +127,6 @@ import { type AxiosError, type AxiosInstance } from 'axios'
 import { computed, inject, ref, watch } from 'vue'
 import { onBeforeRouteLeave, useRouter } from 'vue-router'
 
-import { apiLegacySoftProjectDelete, apiLegacySoftSitesDelete } from '@rfcx-bio/common/api-arbimon/audiodata/sites'
 import { type ProjectProfileUpdateBody, ERROR_MESSAGE_UPDATE_PROJECT_SLUG_NOT_UNIQUE } from '@rfcx-bio/common/api-bio/project/project-settings'
 import { dayjs } from '@rfcx-bio/utils/dayjs-initialized'
 import { isValidSlug } from '@rfcx-bio/utils/string/slug'
@@ -143,13 +134,11 @@ import { isValidSlug } from '@rfcx-bio/utils/string/slug'
 import SaveStatusText from '@/_components/save-status-text.vue'
 import ReadOnlyBanner from '@/_layout/components/guest-banner/guest-banner.vue'
 import { urlWrapper } from '@/_services/images/url-wrapper'
-import { apiClientArbimonLegacyKey, apiClientKey, togglesKey } from '@/globals'
+import { apiClientKey, togglesKey } from '@/globals'
 import ProjectStateBadge from '@/projects/components/project-state-badge.vue'
-import { ROUTE_NAMES } from '~/router'
 import { useDashboardStore, useStore } from '~/store'
-import { useDeleteProject, useGetProjectSettings, useUpdateProjectImage, useUpdateProjectSettings } from './_composables/use-project-profile'
+import { useGetProjectSettings, useUpdateProjectImage, useUpdateProjectSettings } from './_composables/use-project-profile'
 import { verifyDateFormError } from './components/form/functions'
-import ProjectDelete from './components/form/project-delete.vue'
 import ProjectForm from './components/form/project-form.vue'
 import ProjectImageForm from './components/form/project-image-form.vue'
 import ProjectListedForm from './components/form/project-listed-form.vue'
@@ -163,16 +152,13 @@ const router = useRouter()
 const store = useStore()
 const dashboardStore = useDashboardStore()
 const apiClientBio = inject(apiClientKey) as AxiosInstance
-const apiClientArbimon = inject(apiClientArbimonLegacyKey) as AxiosInstance
 const toggles = inject(togglesKey)
 const selectedProject = computed(() => store.project)
 const selectedProjectId = computed(() => store.project?.id)
-const selectedProjectSlug = computed(() => store.project?.slug ?? '')
 
 const { data: settings, isError: isErrorSetting } = useGetProjectSettings(apiClientBio, selectedProjectId)
 const { mutate: mutateProjectSettings } = useUpdateProjectSettings(apiClientBio, store.project?.id ?? -1)
 const { mutate: mutatePatchProfilePhoto } = useUpdateProjectImage(apiClientBio, store.project?.id ?? -1)
-const { isPending: isDeletingProject, isError: isErrorDeleteProject, isSuccess: isSuccessDeleteProject, mutate: mutateDeleteProject } = useDeleteProject(apiClientBio)
 
 const newName = ref('')
 const dateStart = ref<string | null>(null)
@@ -242,17 +228,6 @@ const onEmitProjectImage = (file: File) => {
 const onEmitSlug = (slug: string) => {
   newSlug.value = slug
   updateLastModified()
-}
-
-const onEmitProjectDelete = () => {
-  mutateDeleteProject(store.project?.id ?? -1, {
-    onSuccess: async () => {
-      await apiLegacySoftProjectDelete(apiClientArbimon, selectedProjectSlug.value ?? '')
-      await apiLegacySoftSitesDelete(apiClientArbimon, selectedProjectSlug.value ?? '')
-      store.deleteProject(store.project?.id)
-      await router.push({ name: ROUTE_NAMES.myProjects })
-    }
-  })
 }
 
 const toggleListedProject = (value: boolean) => {


### PR DESCRIPTION
## What

Two GUI removals on the **Project settings** page (`apps/website/src/projects/project-settings-page.vue`):

1. **Danger Zone** — removed the entire 'Danger Zone' section (the *Delete project* button + confirmation modal). Also removed the now-orphaned imports/state it depended on (`project-delete` component, `useDeleteProject`, `apiLegacySoftProjectDelete`/`apiLegacySoftSitesDelete`, `onEmitProjectDelete` handler, and the now-unused `ROUTE_NAMES` / `apiClientArbimon` / `selectedProjectSlug`).
2. **Request backup button** — removed the visible 'Request backup' mailto button from the **Project backup** section. The instructional text ('please send an email to jon@rfcx.org') is retained.

## Notes
- The `components/form/project-delete.vue` component file is now unreferenced (left in place; can be deleted in a follow-up cleanup if desired).
- The pre-existing *hidden* self-service backup button (`class="...hidden"`) and its modal/composable are untouched.

## Validation
- `eslint` on both changed files: clean (exit 0).
- `vue-tsc --noEmit` typecheck on the website package: clean (exit 0).

## Deploy
Merge to `master` triggers the rfcx-local CD (`cd.yaml` → `rfcx-local-cd.yaml@master`), which builds and rolls `biodiversity-website` in the production namespace.