### PR TITLE
fix(api): apply super-user bypass to all project-scoped permission checks

### DIFF
--- a/apps/api/src/_plugins/project-role.ts
+++ b/apps/api/src/_plugins/project-role.ts
@@ -3,6 +3,7 @@ import fp from 'fastify-plugin'
 
 import { type ProjectRole } from '@rfcx-bio/common/roles'
 
+import { isSuperUser } from '@/_services/auth0/is-super-user'
 import { getUserRoleForProject } from '@/projects/dao/project-member-dao'
 
 const plugin: FastifyPluginCallback = (instance, _options, done) => {
@@ -19,7 +20,19 @@ const plugin: FastifyPluginCallback = (instance, _options, done) => {
 
     const role = await getUserRoleForProject(request.userId, projectId)
     // TODO: cache this result
-    request.projectRole = role
+
+    // Super-user bypass: org-level support/scientist accounts (allow-list in
+    // SUPER_USER_EMAILS) are escalated to 'admin' on any project they aren't an
+    // explicit member of, for every project-scoped permission check (members,
+    // insights, profile, etc.) -- not only the project-by-slug lookup.
+    //
+    // This mirrors `getProjectBySlugForUser` in projects-bll.ts, which already
+    // escalates super users to 'admin'. Without the same bypass here, a super
+    // user could load a project's overview (escalated) but still get a 403 from
+    // `requireProjectPermission` on /members, /filters, etc. (role resolved to
+    // 'none'). We escalate to 'admin' rather than 'owner' so owner-only
+    // operations (e.g. project deletion) still require a real owner membership.
+    request.projectRole = role === 'none' && isSuperUser(request) ? 'admin' : role
   })
 
   done()

--- a/apps/api/src/_plugins/project-role.unit.test.ts
+++ b/apps/api/src/_plugins/project-role.unit.test.ts
@@ -1,0 +1,64 @@
+import fastify, { type FastifyInstance } from 'fastify'
+import { afterEach, beforeEach, expect, test, vi } from 'vitest'
+
+import { type ProjectRole } from '@rfcx-bio/common/roles'
+
+vi.mock('~/env', () => ({ env: { SUPER_USER_EMAILS: '' } }))
+vi.mock('@/projects/dao/project-member-dao', () => ({ getUserRoleForProject: vi.fn() }))
+
+const method = 'GET'
+const url = '/projects/:projectId/probe'
+
+const getApp = async (opts: { email?: string, userId?: number, dbRole: ProjectRole }): Promise<FastifyInstance> => {
+  vi.resetModules()
+  const { env } = await import('~/env')
+  env.SUPER_USER_EMAILS = 'support@rfcx.org,arbimon-admin@rfcx.org'
+
+  const { getUserRoleForProject } = await import('@/projects/dao/project-member-dao')
+  ;(getUserRoleForProject as unknown as ReturnType<typeof vi.fn>).mockResolvedValue(opts.dbRole)
+
+  const { projectRolePlugin } = await import('./project-role')
+
+  const app = await fastify()
+  app.decorateRequest('userToken', opts.email === undefined ? null : { email: opts.email, idAuth0: 'auth0|x', firstName: '', lastName: '' })
+  app.decorateRequest('userId', opts.userId)
+  await app.register(projectRolePlugin)
+  app.route({ method, url, handler: async (req) => await Promise.resolve({ projectRole: req.projectRole }) })
+  return app
+}
+
+afterEach(() => { vi.clearAllMocks() })
+beforeEach(() => { vi.resetModules() })
+
+test('escalates a super user with no membership (db role "none") to "admin"', async () => {
+  const app = await getApp({ email: 'arbimon-admin@rfcx.org', userId: 17201, dbRole: 'none' })
+  const response = await app.inject({ method, url: '/projects/1142218/probe' })
+  expect(JSON.parse(response.body).projectRole).toBe('admin')
+})
+
+test('does NOT escalate a non-super user with no membership (stays "none")', async () => {
+  const app = await getApp({ email: 'someone@example.com', userId: 42, dbRole: 'none' })
+  const response = await app.inject({ method, url: '/projects/1142218/probe' })
+  expect(JSON.parse(response.body).projectRole).toBe('none')
+})
+
+test('does NOT override a real membership role for a super user (no privilege downgrade/upgrade)', async () => {
+  const app = await getApp({ email: 'arbimon-admin@rfcx.org', userId: 17201, dbRole: 'viewer' })
+  const response = await app.inject({ method, url: '/projects/1142218/probe' })
+  // a super user who is an explicit member keeps their actual membership role
+  expect(JSON.parse(response.body).projectRole).toBe('viewer')
+})
+
+test('does NOT escalate when no projectId param is present', async () => {
+  const { env } = await import('~/env')
+  env.SUPER_USER_EMAILS = 'support@rfcx.org'
+  const { projectRolePlugin } = await import('./project-role')
+  const app = await fastify()
+  app.decorateRequest('userToken', { email: 'support@rfcx.org', idAuth0: 'auth0|x', firstName: '', lastName: '' })
+  app.decorateRequest('userId', 1)
+  await app.register(projectRolePlugin)
+  app.route({ method: 'GET', url: '/no-project', handler: async (req) => await Promise.resolve({ projectRole: req.projectRole }) })
+  const response = await app.inject({ method: 'GET', url: '/no-project' })
+  // default decorated value, untouched
+  expect(JSON.parse(response.body).projectRole).toBe('none')
+})


### PR DESCRIPTION
## Problem
Super users (org accounts in `SUPER_USER_EMAILS`) get a **403** on a project's **Members** and **insights** pages for projects they aren't explicit members of.

Live repro: `arbimon-admin@rfcx.org` opening https://arbimon.org/p/giant-burrowing-frogs/users → page shows *"It seems the page didn't load as expected"*. Network:
- `GET /api/projects/1142218/members` → **403** (`requireProjectPermission('read-users')`)
- `GET /api/projects/1142218/filters` → **403** (`requireProjectPermission('read-insights')`)
- `GET /api/projects/1142218/role` → `"none"`

(Project `giant-burrowing-frogs` = id 1142218, status `unlisted`; the user is not a member.)

## Root cause
The `SUPER_USER_EMAILS` → `admin` escalation lived **only** in `getProjectBySlugForUser` (projects-bll.ts, the project-by-slug lookup). The `project-role` Fastify plugin — which sets `req.projectRole` for **every** `requireProjectPermission` route — called `getUserRoleForProject` with **no** super-user bypass. So a super user is escalated on the project-overview call but still resolves to `none` (→ 403) on members/filters/insights/etc.

## Fix
Move the escalation into the `project-role` plugin so `req.projectRole` is consistently escalated for super users across all project-scoped permission checks. Escalate to `admin` (not `owner`) so owner-only ops (project deletion) still require a real owner membership — matching `getProjectBySlugForUser`.

## Tests
Adds `project-role.unit.test.ts`:
- super user + db role `none` → `admin`
- non-super user + `none` → stays `none`
- super user **with** a real membership role → role unchanged (no override)
- no `projectId` param → no-op

`vitest run` (4/4 pass), `tsc --noEmit` clean, `eslint` clean.

## Notes
- Targeted at **master** as a production hotfix (deployed image == master HEAD; master-push triggers rfcx-local CD). **`develop` needs the same change** on next promote to avoid a regression.
- Separately, the prod `biodiversity-api` pods predate the `SUPER_USER_EMAILS` secret update and currently load it **empty** — a `rollout restart` is also needed for the allow-list to take effect at all (infra, handled separately).