### PR TITLE
fix(visualizer): default audio playback gain to x1 (was x50)

### DIFF
--- a/apps/website/src/projects/audiodata/visualizer/components/sidebar-spectrogram-player.vue
+++ b/apps/website/src/projects/audiodata/visualizer/components/sidebar-spectrogram-player.vue
@@ -143,7 +143,9 @@ const currentTime = ref(0)
 const duration = ref(0)
 const isGainOpen = ref(false)
 const gainLevels = [1, 2, 5, 10, 15, 20, 25, 30, 50]
-const currentIndex = ref(8)
+// Default to x1 (no gain). gainLevels[0] === 1; index 8 (x50) was applying a
+// 50x gain to playback by default.
+const currentIndex = ref(0)
 
 const selectedGain = computed(() => gainLevels[currentIndex.value])
 


### PR DESCRIPTION
## Problem
In the visualizer, audio playback is amplified **50x by default**. Repro: open a recording, e.g. https://arbimon.org/p/giant-burrowing-frogs/visualizer/rec/308896950 — playback is heavily over-amplified until the user manually drags the gain slider down to x1.

## Root cause
`apps/website/src/projects/audiodata/visualizer/components/sidebar-spectrogram-player.vue`:
```js
const gainLevels = [1, 2, 5, 10, 15, 20, 25, 30, 50]
const currentIndex = ref(8)   // gainLevels[8] === 50  -> 50x by default
```
`currentIndex` (the gain-slider position) initialized to the **last** level (x50). `createAudio()` then appends `?gain=50` to the legacy audio URL on load.

## Fix
Default `currentIndex` to `0` → `gainLevels[0] === 1` (no gain). One-line change.

eslint clean. Targeted at **master** as a production fix (deployed image == master HEAD); `develop` should get the same change on next promote.