### PR TITLE
feat(species-list): show 'Also known as' (aliases) on project species list

### DIFF
--- a/apps/website/src/projects/audiodata/species-page.vue
+++ b/apps/website/src/projects/audiodata/species-page.vue
@@ -264,6 +264,7 @@ watch(
 
 const columns = [
   { label: 'Species', key: 'species_name', maxWidth: 90 },
+  { label: 'Also known as', key: 'aliases', maxWidth: 120 },
   { label: 'Taxon', key: 'taxon', maxWidth: 70 },
   { label: 'Sound', key: 'songtype_name', maxWidth: 70 },
   { label: 'Project Templates', key: 'project_templates', maxWidth: 150 },
@@ -320,6 +321,16 @@ const mergedSpecies = computed(() => {
 
     return {
       ...s,
+      // 'aliases' (other/former names) comes from the legacy project/classes
+      // endpoint as a comma-joined string; tidy it (trim, drop blanks) so the
+      // 'Also known as' column renders cleanly. Kept on the row so e.g. a
+      // renamed species (Tyto alba furcata -> Tyto furcata pratincola) still
+      // shows its former name to projects that already track it.
+      aliases: (s.aliases ?? '')
+        .split(',')
+        .map(a => a.trim())
+        .filter(a => a.length > 0)
+        .join(', '),
       project_templates: sortByDateCreatedDesc(projMap.get(key) ?? []),
       public_templates: sortByDateCreatedDesc(pubMap.get(key) ?? [])
     }

--- a/packages/common/src/api-arbimon/audiodata/species.ts
+++ b/packages/common/src/api-arbimon/audiodata/species.ts
@@ -13,6 +13,10 @@ export interface SpeciesType {
   species: number
   species_name: string
   taxon: string
+  // Comma-joined list of the species' other/former names (common names +
+  // superseded scientific names) from species_aliases. May be absent on
+  // older API builds.
+  aliases?: string
 }
 
 export interface SpeciesClassesParams {


### PR DESCRIPTION
## What
The main project species list (Species page) now shows an **"Also known as"** column with each species' other/former names (common names + superseded scientific names).

## Why
Follow-on to #2488 (which added aliases to the *Species Library picker*). This adds them to the *main list* of species already in a project. Motivated by the in-place rename `Tyto alba furcata` → `Tyto furcata pratincola`: the former name was preserved only as a DB alias and was invisible in the UI. Projects that already track the bird now see both the current name and the former name.

## How
- Add 'Also known as' column to `species-page.vue`.
- Clean the comma-joined `aliases` string in `mergedSpecies` (trim, drop blanks) — same pattern as the picker.
- Add optional `aliases` to `SpeciesType`.

## Depends on
rfcx/arbimon-legacy#1728 (adds the `aliases` field to `/project/:slug/classes`). If the website deploys first, the column degrades gracefully to '-' (no error). **Merge arbimon-legacy#1728 first.**

ESLint: clean. Companion develop-sync PR to follow.