### PR TITLE
fix(species-library): widen modal + columns so species names don't truncate

### DIFF
--- a/apps/website/src/projects/audiodata/component/create-species.vue
+++ b/apps/website/src/projects/audiodata/component/create-species.vue
@@ -3,7 +3,7 @@
     v-if="isOpen"
     class="fixed inset-0 bg-black bg-opacity-60 flex items-center justify-center z-50"
   >
-    <div class="bg-moss text-white rounded-xl p-6 w-full shadow-lg relative w-[900px] overflow-y-auto">
+    <div class="bg-moss text-white rounded-xl p-6 shadow-lg relative w-[1100px] max-w-[95vw] overflow-y-auto">
       <button
         class="absolute right-4"
         type="button"
@@ -118,10 +118,10 @@ const speciesRows = computed(() => (speciesData.value ?? []).map(s => ({
 const { data: songtypesSpecies } = useSongtypesSpecies(apiClientArbimon)
 
 const columns = [
-  { label: 'Species', key: 'scientific_name', maxWidth: 90 },
-  { label: 'Other names', key: 'aliases', maxWidth: 120 },
-  { label: 'Family', key: 'family', maxWidth: 70 },
-  { label: 'Taxon', key: 'taxon', maxWidth: 70 }
+  { label: 'Species', key: 'scientific_name', maxWidth: 220 },
+  { label: 'Other names', key: 'aliases', maxWidth: 240 },
+  { label: 'Family', key: 'family', maxWidth: 140 },
+  { label: 'Taxon', key: 'taxon', maxWidth: 90 }
 ]
 
 function open () {


### PR DESCRIPTION
## Problem
In the Species Library picker (e.g. on /p/<slug>/audiodata/species → New species), long scientific/alias names like **Tyto furcata pratincola** were truncated. Cause: the modal is fixed at 900px and the table columns use small `maxWidth` props (Species 90, Other names 120, Family/Taxon 70), and the shared SortableTable hard-clips each cell to `max-width` + `truncate`.

## Change (Option 1 — scoped to this modal)
- Modal width `900px` → `1100px` with `max-w-[95vw]` (responsive; no small-screen overflow). Dropped the redundant `w-full`.
- Column `maxWidth` raised: Species 90→220, Other names 120→240, Family 70→140, Taxon 70→90.

## Blast radius
**None outside this modal.** Only `create-species.vue`'s own props change; `SortableTable` is untouched, so the Recordings, Sites, and main species-list tables (the other 3 consumers) are unaffected. The picker only exists on this page.

(Drag-resizable columns would require changing the shared SortableTable — deferred as a separate, broader piece.)

ESLint: 0 new issues.

## Deploy
master → rfcx-local CD builds + rolls biodiversity-website. Companion develop-sync PR to follow.