### PR TITLE
chore(species-library): sync modal/column widths to develop

### DIFF
--- a/apps/website/src/projects/audiodata/component/create-species.vue
+++ b/apps/website/src/projects/audiodata/component/create-species.vue
@@ -3,7 +3,7 @@
     v-if="isOpen"
     class="fixed inset-0 bg-black bg-opacity-60 flex items-center justify-center z-50"
   >
-    <div class="bg-moss text-white rounded-xl p-6 w-full shadow-lg relative w-[900px] overflow-y-auto">
+    <div class="bg-moss text-white rounded-xl p-6 shadow-lg relative w-[1100px] max-w-[95vw] overflow-y-auto">
       <button
         class="absolute right-4"
         type="button"
@@ -118,10 +118,10 @@ const speciesRows = computed(() => (speciesData.value ?? []).map(s => ({
 const { data: songtypesSpecies } = useSongtypesSpecies(apiClientArbimon)
 
 const columns = [
-  { label: 'Species', key: 'scientific_name', maxWidth: 90 },
-  { label: 'Other names', key: 'aliases', maxWidth: 120 },
-  { label: 'Family', key: 'family', maxWidth: 70 },
-  { label: 'Taxon', key: 'taxon', maxWidth: 70 }
+  { label: 'Species', key: 'scientific_name', maxWidth: 220 },
+  { label: 'Other names', key: 'aliases', maxWidth: 240 },
+  { label: 'Family', key: 'family', maxWidth: 140 },
+  { label: 'Taxon', key: 'taxon', maxWidth: 90 }
 ]
 
 function open () {


### PR DESCRIPTION
Sync of #2492 (merged to master) into develop. Widens the Species Library modal to 1100px (max-w-95vw) + raises column maxWidths so species names don't truncate. Scoped to create-species.vue. Applies on top of the now-synced #2489/#2491.