### PR TITLE
fix(visualizer): link internal visualizer entry points to legacy /project/

### DIFF
--- a/apps/website/src/detect/cnn-job-detail/components/detection-item.vue
+++ b/apps/website/src/detect/cnn-job-detail/components/detection-item.vue
@@ -261,7 +261,10 @@ const onVisualizerRedirect = async (): Promise<void> => {
     emit('showAlertDialog')
     return
   }
-  window.location.assign(`${window.location.origin}/p/${store.project?.slug}/visualizer/rec/${response}`)
+  // Route to the legacy visualizer (/project/...): the modern /p/ visualizer is
+  // currently redirected to legacy at the edge (public-router) due to a
+  // feature/stability gap. Link straight to legacy to skip the 302 hop.
+  window.location.assign(`${window.location.origin}/project/${store.project?.slug}/visualizer/rec/${response}`)
 }
 
 const toggleDetection = (event: MouseEvent) => {

--- a/apps/website/src/projects/audiodata/component/sortable-table.vue
+++ b/apps/website/src/projects/audiodata/component/sortable-table.vue
@@ -432,7 +432,10 @@ function toggleRow (row: Row, checked: boolean) {
 }
 
 const onVisualizerRedirect = (id: number) => {
-  window.location.assign(`${window.location.origin}/p/${props.projectSlug ?? ''}/visualizer/rec/${id}`)
+  // Route to the legacy visualizer (/project/...): the modern /p/ visualizer is
+  // currently redirected to legacy at the edge (public-router) due to a
+  // feature/stability gap. Link straight to legacy to skip the 302 hop.
+  window.location.assign(`${window.location.origin}/project/${props.projectSlug ?? ''}/visualizer/rec/${id}`)
 }
 
 const areAllRowsSelected = computed(() => {

--- a/apps/website/src/projects/audiodata/visualizer/components/sidebar-soundscape-regions.vue
+++ b/apps/website/src/projects/audiodata/visualizer/components/sidebar-soundscape-regions.vue
@@ -264,7 +264,10 @@ const toggleSoundscapeRegionVisibility = (region: SoundscapeRegion) => {
 }
 
 const viewPlaylist = (region: SoundscapeRegion) => {
-  return window.location.assign(`${window.location.origin}/p/${store.project?.slug ?? ''}/visualizer/playlist/${region.playlist}`)
+  // Route to the legacy visualizer (/project/...): the modern /p/ visualizer is
+  // currently redirected to legacy at the edge (public-router) due to a
+  // feature/stability gap. Link straight to legacy to skip the 302 hop.
+  return window.location.assign(`${window.location.origin}/project/${store.project?.slug ?? ''}/visualizer/playlist/${region.playlist}`)
 }
 
 watch(() => browserTypeId.value, () => {


### PR DESCRIPTION
Follow-up polish to the visualizer repoint. The modern `/p/<slug>/visualizer` is currently redirected to the legacy `/project/<slug>/visualizer` at the edge (rfcx-local public-router) because the modern visualizer has a feature/stability gap (hangs on load). 

This points the modern app's full-page visualizer-**entry** links straight at `/project/` so users skip the extra 302 hop:
- `detection-item.vue` (CNN job detail → recording)
- `sortable-table.vue` (recordings/species list → recording)
- `sidebar-soundscape-regions.vue` (view playlist)

Cosmetic only — the edge redirect already handles `/p/` visualizer URLs. Left `sidebar-thumbnail`'s in-SPA `router.push` alone (internal tab normalization, not an entry hop). **Reverse these when the modern visualizer reaches parity and the edge redirect is removed.** ESLint: 0 new issues. Develop-sync PR to follow.