### PR TITLE
chore(visualizer): sync legacy-link repoint to develop

### DIFF
--- a/apps/website/src/detect/cnn-job-detail/components/detection-item.vue
+++ b/apps/website/src/detect/cnn-job-detail/components/detection-item.vue
@@ -261,7 +261,10 @@ const onVisualizerRedirect = async (): Promise<void> => {
     emit('showAlertDialog')
     return
   }
-  window.location.assign(`${window.location.origin}/p/${store.project?.slug}/visualizer/rec/${response}`)
+  // Route to the legacy visualizer (/project/...): the modern /p/ visualizer is
+  // currently redirected to legacy at the edge (public-router) due to a
+  // feature/stability gap. Link straight to legacy to skip the 302 hop.
+  window.location.assign(`${window.location.origin}/project/${store.project?.slug}/visualizer/rec/${response}`)
 }
 
 const toggleDetection = (event: MouseEvent) => {

--- a/apps/website/src/projects/audiodata/component/sortable-table.vue
+++ b/apps/website/src/projects/audiodata/component/sortable-table.vue
@@ -432,7 +432,10 @@ function toggleRow (row: Row, checked: boolean) {
 }
 
 const onVisualizerRedirect = (id: number) => {
-  window.location.assign(`${window.location.origin}/p/${props.projectSlug ?? ''}/visualizer/rec/${id}`)
+  // Route to the legacy visualizer (/project/...): the modern /p/ visualizer is
+  // currently redirected to legacy at the edge (public-router) due to a
+  // feature/stability gap. Link straight to legacy to skip the 302 hop.
+  window.location.assign(`${window.location.origin}/project/${props.projectSlug ?? ''}/visualizer/rec/${id}`)
 }
 
 const areAllRowsSelected = computed(() => {

--- a/apps/website/src/projects/audiodata/visualizer/components/sidebar-soundscape-regions.vue
+++ b/apps/website/src/projects/audiodata/visualizer/components/sidebar-soundscape-regions.vue
@@ -264,7 +264,10 @@ const toggleSoundscapeRegionVisibility = (region: SoundscapeRegion) => {
 }
 
 const viewPlaylist = (region: SoundscapeRegion) => {
-  return window.location.assign(`${window.location.origin}/p/${store.project?.slug ?? ''}/visualizer/playlist/${region.playlist}`)
+  // Route to the legacy visualizer (/project/...): the modern /p/ visualizer is
+  // currently redirected to legacy at the edge (public-router) due to a
+  // feature/stability gap. Link straight to legacy to skip the 302 hop.
+  return window.location.assign(`${window.location.origin}/project/${store.project?.slug ?? ''}/visualizer/playlist/${region.playlist}`)
 }
 
 watch(() => browserTypeId.value, () => {


### PR DESCRIPTION
Sync of #2496 (merged to master). Points internal visualizer-entry links to legacy /project/ to skip the edge 302 hop. Reverse when modern visualizer reaches parity.