### PR TITLE
fix(cli): send descriptive User-Agent to Wikimedia APIs (deploy to rfcx-local)

### DIFF
--- a/apps/cli/src/ingest/_refactor/input-wiki/get-wiki-image-info.ts
+++ b/apps/cli/src/ingest/_refactor/input-wiki/get-wiki-image-info.ts
@@ -2,6 +2,7 @@ import axios, { type AxiosRequestConfig } from 'axios'
 
 import { logError } from '~/axios'
 import { requireEnv } from '~/env'
+import { WIKI_USER_AGENT } from './user-agent'
 
 export interface WikiMediaImageInfo {
   descriptionurl: string
@@ -26,7 +27,10 @@ export async function getWikiImageInfo (fileName: string | undefined): Promise<W
   if (!fileName) return undefined
   const endpoint: AxiosRequestConfig = {
     method: 'GET',
-    url: `${WIKI_MEDIA_BASE_URL}/w/api.php?action=query&prop=imageinfo&iiprop=extmetadata|url&format=json&titles=File:${fileName}`
+    url: `${WIKI_MEDIA_BASE_URL}/w/api.php?action=query&prop=imageinfo&iiprop=extmetadata|url&format=json&titles=File:${fileName}`,
+    headers: {
+      'User-Agent': WIKI_USER_AGENT
+    }
   }
 
   return await axios.request<WikiMediaResponse>(endpoint)

--- a/apps/cli/src/ingest/_refactor/input-wiki/get-wiki-species.ts
+++ b/apps/cli/src/ingest/_refactor/input-wiki/get-wiki-species.ts
@@ -2,6 +2,7 @@ import axios, { type AxiosRequestConfig } from 'axios'
 
 import { logError } from '~/axios'
 import { requireEnv } from '~/env'
+import { WIKI_USER_AGENT } from './user-agent'
 
 export interface WikiSummaryResponse {
   type: string
@@ -59,7 +60,10 @@ const { WIKI_BASE_URL } = requireEnv('WIKI_BASE_URL')
 export async function getWikiSpecies (scientificName: string): Promise<WikiSummaryResponse | undefined> {
   const endpoint: AxiosRequestConfig = {
     method: 'GET',
-    url: `${WIKI_BASE_URL}/api/rest_v1/page/summary/${scientificName}`
+    url: `${WIKI_BASE_URL}/api/rest_v1/page/summary/${scientificName}`,
+    headers: {
+      'User-Agent': WIKI_USER_AGENT
+    }
   }
 
   return await axios.request<WikiSummaryResponse>(endpoint)

--- a/apps/cli/src/ingest/_refactor/input-wiki/user-agent.ts
+++ b/apps/cli/src/ingest/_refactor/input-wiki/user-agent.ts
@@ -1,0 +1,7 @@
+// Wikimedia's API Policy (see https://phabricator.wikimedia.org/T400119 and
+// https://meta.wikimedia.org/wiki/User-Agent_policy) requires every API client
+// to send a descriptive User-Agent that identifies the application and a way
+// to contact the operator. Anonymous / generic UAs (including axios's default
+// `axios/<version>`) are now blocked with HTTP 403, which breaks the daily
+// Wiki species sync. Keep this string descriptive and include contact info.
+export const WIKI_USER_AGENT = 'BiodiversityCLI/1.0 (https://github.com/rfcx/arbimon; support@rfcx.org)'


### PR DESCRIPTION
Master-targeted cherry-pick of #2483 (which merged to develop) so the rfcx-local CD rebuilds `biodiversity-cli` and the fix actually deploys.

## Why
`biodiversity-cli-sync-daily` has been FAILING every run: Wikimedia now 403s the default axios User-Agent (`axios/<version>`) per their API policy (phab T400119). Every `getWikiSummary`/`getWikiImageInfo` call fails, leaving `taxon_species_wiki` un-refreshed and stretching the job until the kubectl wait times out.

## What
Adds a descriptive `WIKI_USER_AGENT` (`BiodiversityCLI/1.0 (https://github.com/rfcx/arbimon; support@rfcx.org)`) header on the two Wikimedia calls. +17/-2, no other behavior change. Identical to #2483 (commit 6f9beb6). ESLint clean.

## Deploy
master → rfcx-local CD builds `biodiversity-cli` (among targets). After roll, verify the daily/incremental sync crons pick up the new image and go green.