### PR TITLE
feat(cli): split daily sync into IUCN/Wiki/mviews + IUCN UA+backoff

### DIFF
--- a/apps/cli/src/ingest/_refactor/input-iucn/iucn-request.ts
+++ b/apps/cli/src/ingest/_refactor/input-iucn/iucn-request.ts
@@ -1,0 +1,54 @@
+import axios, { type AxiosRequestConfig, type AxiosResponse } from 'axios'
+import { setTimeout as asyncTimeout } from 'node:timers/promises'
+
+// Descriptive User-Agent. Wikimedia already required this (see input-wiki/
+// user-agent.ts); IUCN is friendlier to identified clients too, and it keeps
+// our outbound calls attributable + contactable.
+export const IUCN_USER_AGENT = 'BiodiversityCLI/1.0 (https://github.com/rfcx/arbimon; support@rfcx.org)'
+
+const MAX_RETRIES = 4
+const BASE_DELAY_MS = 2_000
+
+const parseRetryAfterMs = (res: AxiosResponse | undefined): number | undefined => {
+  const ra = res?.headers?.['retry-after']
+  if (ra == null) return undefined
+  const secs = Number(ra)
+  if (!Number.isNaN(secs)) return secs * 1_000
+  const when = Date.parse(String(ra))
+  if (!Number.isNaN(when)) return Math.max(0, when - Date.now())
+  return undefined
+}
+
+/**
+ * IUCN HTTP GET with a descriptive User-Agent + retry/backoff on 429 (and 5xx).
+ *
+ * IUCN rate-limits aggressively; the daily sync was hammering it and getting a
+ * flood of 429s with no backoff, which both slowed throughput and risked
+ * incomplete data. This honors `Retry-After` when present, otherwise uses
+ * exponential backoff. Non-retryable statuses (e.g. 404) are thrown straight
+ * back so existing `.catch(logError(...))` handling is unchanged.
+ */
+export async function iucnRequest <T> (config: AxiosRequestConfig): Promise<AxiosResponse<T>> {
+  const merged: AxiosRequestConfig = {
+    ...config,
+    headers: { 'User-Agent': IUCN_USER_AGENT, ...config.headers }
+  }
+
+  let attempt = 0
+  let delay = BASE_DELAY_MS
+  for (;;) {
+    try {
+      return await axios.request<T>(merged)
+    } catch (error) {
+      const status = axios.isAxiosError(error) ? error.response?.status : undefined
+      const retryable = status === 429 || (status !== undefined && status >= 500)
+      if (!retryable || attempt >= MAX_RETRIES) throw error
+
+      const waitMs = parseRetryAfterMs(axios.isAxiosError(error) ? error.response : undefined) ?? delay
+      console.info(`[iucn-retry] ${status} — backing off ${Math.round(waitMs / 1000)}s (attempt ${attempt + 1}/${MAX_RETRIES})`)
+      await asyncTimeout(waitMs)
+      delay *= 2
+      attempt++
+    }
+  }
+}

--- a/apps/cli/src/ingest/_refactor/input-iucn/iucn-species-narrative.ts
+++ b/apps/cli/src/ingest/_refactor/input-iucn/iucn-species-narrative.ts
@@ -1,8 +1,9 @@
-import axios, { type AxiosRequestConfig, type AxiosResponse } from 'axios'
+import { type AxiosRequestConfig, type AxiosResponse } from 'axios'
 
 import { getIucnSpecies } from '@/ingest/_refactor/input-iucn/iucn-species'
 import { requireEnv } from '~/env'
 import { logError } from '../../../_services/axios'
+import { iucnRequest } from './iucn-request'
 
 const { IUCN_BASE_URL, IUCN_API_KEY } = requireEnv('IUCN_BASE_URL', 'IUCN_API_KEY')
 
@@ -57,7 +58,7 @@ export async function getIucnSpeciesNarrative (scientificName: string): Promise<
     url: `${IUCN_BASE_URL}/assessment/${assessmentId}`
   }
 
-  return await axios.request<IucnSpeciesNarrativeResponse>(endpoint)
+  return await iucnRequest<IucnSpeciesNarrativeResponse>(endpoint)
     .then(mapResult(scientificName))
     .catch(logError('getIucnSpeciesNarrative', scientificName, '(no data)'))
 }

--- a/apps/cli/src/ingest/_refactor/input-iucn/iucn-species.ts
+++ b/apps/cli/src/ingest/_refactor/input-iucn/iucn-species.ts
@@ -1,7 +1,8 @@
-import axios, { type AxiosRequestConfig, type AxiosResponse } from 'axios'
+import { type AxiosRequestConfig, type AxiosResponse } from 'axios'
 
 import { requireEnv } from '~/env'
 import { logError } from '../../../_services/axios'
+import { iucnRequest } from './iucn-request'
 import { getSpeciesApiRedirectLink } from './utils'
 
 // TODO: This should be injected by the script controller
@@ -65,7 +66,7 @@ export async function getIucnSpecies (scientificName: string): Promise<IucnSpeci
     url: getSpeciesApiRedirectLink(scientificName)
   }
 
-  return await axios.request<IucnSpeciesResponse>(endpoint)
+  return await iucnRequest<IucnSpeciesResponse>(endpoint)
     .then(mapResult(scientificName))
     .catch(logError('getIucnSpecies', scientificName, '(no data)'))
 }

--- a/apps/cli/src/ingest/refresh-mviews.ts
+++ b/apps/cli/src/ingest/refresh-mviews.ts
@@ -1,0 +1,10 @@
+import { refreshMviews } from '../db/actions/refresh-mviews'
+import { getSequelize } from '../db/connections'
+
+const main = async (): Promise<void> => {
+  const sequelize = getSequelize()
+  await refreshMviews(sequelize)
+  process.exit(0)
+}
+
+await main()

--- a/apps/cli/src/ingest/sync-species-iucn.ts
+++ b/apps/cli/src/ingest/sync-species-iucn.ts
@@ -2,9 +2,17 @@ import { getSequelize } from '../db/connections'
 import { syncOnlyMissingIUCNSpeciesInfo } from './external/iucn'
 
 const main = async (): Promise<void> => {
-  const sequelize = getSequelize()
-  await syncOnlyMissingIUCNSpeciesInfo(sequelize)
-  process.exit(0)
+  console.info('IUCN species sync start')
+  try {
+    const sequelize = getSequelize()
+    await syncOnlyMissingIUCNSpeciesInfo(sequelize)
+    console.info('IUCN species sync end: successful')
+    process.exit(0)
+  } catch (e) {
+    console.error(e)
+    console.info('IUCN species sync end: failed')
+    process.exit(1)
+  }
 }
 
 await main()

--- a/apps/cli/src/ingest/sync-species-wiki.ts
+++ b/apps/cli/src/ingest/sync-species-wiki.ts
@@ -2,9 +2,17 @@ import { getSequelize } from '../db/connections'
 import { syncOnlyMissingWikiSpeciesInfo } from './external/wiki'
 
 const main = async (): Promise<void> => {
-  const sequelize = getSequelize()
-  await syncOnlyMissingWikiSpeciesInfo(sequelize)
-  process.exit(0)
+  console.info('Wiki species sync start')
+  try {
+    const sequelize = getSequelize()
+    await syncOnlyMissingWikiSpeciesInfo(sequelize)
+    console.info('Wiki species sync end: successful')
+    process.exit(0)
+  } catch (e) {
+    console.error(e)
+    console.info('Wiki species sync end: failed')
+    process.exit(1)
+  }
 }
 
 await main()


### PR DESCRIPTION
## Why
The monolithic daily sync runs **IUCN → Wiki → refresh-mviews** in one job under one 1-hour deadline. IUCN has a ~48.5k-species stale backlog and is heavily rate-limited (429s), so it consumes the entire hour and **starves the Wiki enrichment and the mview refresh** — both of which are fast and healthy. One slow upstream takes down two unrelated internal steps.

## What
**Split into 3 independent entrypoints** (so rfcx-local can run them as 3 CronJobs with their own schedules/deadlines):
- `sync-species-iucn.ts`, `sync-species-wiki.ts` — already existed; **hardened**: wrap in try/catch + exit non-zero on failure (previously `process.exit(0)` unconditionally, which masked errors so the CronJob reported success even when the sync threw).
- `refresh-mviews.ts` — **new** standalone entrypoint for `refreshMviews()`.

**IUCN speedup / reliability** (`iucn-request.ts`, new):
- Descriptive `User-Agent` + retry/backoff on **429** and 5xx, honoring `Retry-After`. Routed both `getIucnSpecies` and `getIucnSpeciesNarrative` through it. Non-retryable (e.g. 404) passes straight through to existing `logError` handling.

## Companion / follow-ups
- rfcx-local: split the single `biodiversity-cli-sync-daily` CronJob into 3 (iucn/wiki/mviews) calling these entrypoints, with right-sized deadlines (IUCN long, e.g. weekly + multi-hour; wiki daily; mviews frequent). + one-time backfill Job to drain the 48.5k IUCN backlog.
- **Deferred (noted in commit):** `syncIucnSpeciesInfo` triggers ~2× IUCN /species calls per species (narrative re-fetches species) — deduping would ~halve IUCN load.

ESLint clean. build CI will validate tsc.