### PR TITLE
chore(cli): sync IUCN double-fetch/throttle/batching fix to develop

### DIFF
--- a/apps/cli/src/ingest/_refactor/input-iucn/iucn-species-narrative.ts
+++ b/apps/cli/src/ingest/_refactor/input-iucn/iucn-species-narrative.ts
@@ -45,13 +45,15 @@ interface Documentation {
   use_trade: string | null
 }
 
-export async function getIucnSpeciesNarrative (scientificName: string): Promise<IucnSpeciesNarrative | undefined> {
-  const iucnSpecies = await getIucnSpecies(scientificName)
-  const assessmentId = iucnSpecies?.assessments[0].assessment_id
-  if (assessmentId == null) {
-    console.info('getIucnSpeciesNarrative', scientificName, '(no data)')
-    return undefined
-  }
+/**
+ * Fetch the IUCN assessment narrative for a known assessment id.
+ *
+ * This is the preferred entry point for the sync: the caller already holds the
+ * assessment id (from the species lookup it did anyway), so we make exactly ONE
+ * request to `/assessment/{id}` and do NOT re-fetch `/species`. See the
+ * `getIucnSpeciesNarrative` wrapper below for why that matters.
+ */
+export async function getIucnAssessmentNarrative (assessmentId: number, scientificName: string): Promise<IucnSpeciesNarrative | undefined> {
   const endpoint: AxiosRequestConfig = {
     method: 'GET',
     headers: { Authorization: `Bearer ${IUCN_API_KEY}` },
@@ -61,6 +63,25 @@ export async function getIucnSpeciesNarrative (scientificName: string): Promise<
   return await iucnRequest<IucnSpeciesNarrativeResponse>(endpoint)
     .then(mapResult(scientificName))
     .catch(logError('getIucnSpeciesNarrative', scientificName, '(no data)'))
+}
+
+/**
+ * Backwards-compatible by-name lookup (kept for any external callers).
+ *
+ * WARNING: this makes an extra `getIucnSpecies` call just to obtain the
+ * assessment id. The sync hot path must NOT use this — it already has the
+ * species (and thus the assessment id) in hand, so it calls
+ * `getIucnAssessmentNarrative` directly to avoid doubling IUCN `/species`
+ * traffic across ~48.5k species per run.
+ */
+export async function getIucnSpeciesNarrative (scientificName: string): Promise<IucnSpeciesNarrative | undefined> {
+  const iucnSpecies = await getIucnSpecies(scientificName)
+  const assessmentId = iucnSpecies?.assessments[0].assessment_id
+  if (assessmentId == null) {
+    console.info('getIucnSpeciesNarrative', scientificName, '(no data)')
+    return undefined
+  }
+  return await getIucnAssessmentNarrative(assessmentId, scientificName)
 }
 
 const mapResult = (scientificName: string) => (response: AxiosResponse<IucnSpeciesNarrativeResponse>): IucnSpeciesNarrative | undefined => {

--- a/apps/cli/src/ingest/external/iucn.int.test.ts
+++ b/apps/cli/src/ingest/external/iucn.int.test.ts
@@ -6,7 +6,7 @@ import { type TaxonSpecies } from '@rfcx-bio/node-common/dao/types'
 import { getSequelize } from '@/db/connections'
 import { rawRiskRatings } from '@/db/seeders/_data/risk-rating'
 import { getIucnSpecies } from '@/ingest/_refactor/input-iucn/iucn-species'
-import { getIucnSpeciesNarrative } from '@/ingest/_refactor/input-iucn/iucn-species-narrative'
+import { getIucnAssessmentNarrative } from '@/ingest/_refactor/input-iucn/iucn-species-narrative'
 import { syncOnlyMissingIUCNSpeciesInfo } from './iucn'
 
 // Inputs to the sync from the IUCN API
@@ -76,20 +76,18 @@ vi.mock('@/ingest/_refactor/input-iucn/iucn-species', () => {
 })
 vi.mock('@/ingest/_refactor/input-iucn/iucn-species-narrative', () => {
   return {
-    getIucnSpeciesNarrative: vi.fn(async (scientificName: string) => await Promise.resolve([IUCN_NARRATIVE_SPECIES_1, IUCN_NARRATIVE_SPECIES_2].find(s => s.taxon.scientific_name === scientificName)))
+    // The sync now passes the assessment id it already holds (from the species
+    // lookup) straight to the narrative endpoint, instead of re-fetching
+    // /species inside the narrative call. We still resolve by scientific name
+    // here so the existing fixtures and assertions are preserved.
+    getIucnAssessmentNarrative: vi.fn(async (_assessmentId: number, scientificName: string) => await Promise.resolve([IUCN_NARRATIVE_SPECIES_1, IUCN_NARRATIVE_SPECIES_2].find(s => s.taxon.scientific_name === scientificName)))
   }
 })
-vi.mock('@rfcx-bio/utils/async', () => {
-  return {
-    getSequentially: async <T>(keys: string[], getter: (key: string) => Promise<T | undefined>): Promise<Record<string, T>> => {
-      const results: Record<string, T> = {}
-      for (const key of keys) {
-        const result = await getter(key)
-        if (result !== undefined) results[key] = result
-      }
-      return results
-    }
-  }
+vi.mock('@rfcx-bio/utils/async', async () => {
+  // Preserve real exports (getSequentially, is-fulfilled, etc.) and only make
+  // `wait` instant so the batched sequential pass doesn't add real delays.
+  const actual = await vi.importActual<typeof import('@rfcx-bio/utils/async')>('@rfcx-bio/utils/async')
+  return { ...actual, wait: async () => { await Promise.resolve() } }
 })
 
 const biodiversitySequelize = getSequelize()
@@ -172,7 +170,7 @@ test('risk rating updated after 1 month', async () => {
   await syncOnlyMissingIUCNSpeciesInfo(biodiversitySequelize)
   await biodiversitySequelize.query(`UPDATE taxon_species_iucn SET updated_at = date_trunc('day', updated_at - interval '1 month') WHERE taxon_species_id = ${SPECIES_1.id}`)
   ;(getIucnSpecies as any).mockResolvedValue(undefined)
-  ;(getIucnSpeciesNarrative as any).mockResolvedValue(undefined)
+  ;(getIucnAssessmentNarrative as any).mockResolvedValue(undefined)
 
   // Act
   await syncOnlyMissingIUCNSpeciesInfo(biodiversitySequelize)
@@ -188,7 +186,7 @@ test('risk rating not updated when IUCN data not found', async () => {
   await syncOnlyMissingIUCNSpeciesInfo(biodiversitySequelize)
   await biodiversitySequelize.query(`UPDATE taxon_species_iucn SET updated_at = date_trunc('day', updated_at - interval '1 month') WHERE taxon_species_id = ${SPECIES_1.id}`)
   ;(getIucnSpecies as any).mockResolvedValue(undefined)
-  ;(getIucnSpeciesNarrative as any).mockResolvedValue(undefined)
+  ;(getIucnAssessmentNarrative as any).mockResolvedValue(undefined)
 
   // Act
   await syncOnlyMissingIUCNSpeciesInfo(biodiversitySequelize)
@@ -203,7 +201,7 @@ test('risk rating not updated when getting IUCN data is rejected', async () => {
   await syncOnlyMissingIUCNSpeciesInfo(biodiversitySequelize)
   await biodiversitySequelize.query(`UPDATE taxon_species_iucn SET updated_at = date_trunc('day', updated_at - interval '1 month') WHERE taxon_species_id = ${SPECIES_1.id}`)
   ;(getIucnSpecies as any).mockRejectedValue(new Error('Unexpected'))
-  ;(getIucnSpeciesNarrative as any).mockRejectedValue(new Error('Unexpected'))
+  ;(getIucnAssessmentNarrative as any).mockRejectedValue(new Error('Unexpected'))
   const catchCall = vi.fn()
 
   // Act

--- a/apps/cli/src/ingest/external/iucn.ts
+++ b/apps/cli/src/ingest/external/iucn.ts
@@ -2,13 +2,24 @@ import { type Sequelize, QueryTypes } from 'sequelize'
 
 import { RiskRatingIucnModel } from '@rfcx-bio/node-common/dao/models/risk-rating-iucn-model'
 import { type TaxonSpeciesIucn } from '@rfcx-bio/node-common/dao/types'
-import { getSequentially } from '@rfcx-bio/utils/async'
+import { wait } from '@rfcx-bio/utils/async'
 
 import { getIucnSpecies } from '@/ingest/_refactor/input-iucn/iucn-species'
-import { getIucnSpeciesNarrative } from '@/ingest/_refactor/input-iucn/iucn-species-narrative'
+import { getIucnAssessmentNarrative } from '@/ingest/_refactor/input-iucn/iucn-species-narrative'
 import { writeIucnSpeciesDataToPostgres } from '@/ingest/_refactor/output-bio-db/taxon-species-iucn'
 
 const DEFAULT_RISK_RATING = -1
+
+// How often to flush accumulated rows to Postgres. The previous implementation
+// buffered ALL ~48.5k species in memory and wrote once at the very end, so a
+// multi-hour run that was interrupted (pod eviction, restart, or simply hitting
+// the cron deadline) persisted nothing. Writing in batches makes progress
+// durable and the run cheaply resumable (the WHERE-missing-or-stale selector
+// below already skips rows that were committed on a prior run).
+const WRITE_BATCH_SIZE = 200
+
+// Politeness delay between IUCN species (one sequential pass — see below).
+const REQUEST_SPACING_MS = 500
 
 export const syncOnlyMissingIUCNSpeciesInfo = async (sequelize: Sequelize): Promise<void> => {
   const sql = `
@@ -29,21 +40,44 @@ export const syncOnlyMissingIUCNSpeciesInfo = async (sequelize: Sequelize): Prom
 
 export const syncIucnSpeciesInfo = async (sequelize: Sequelize, speciesNameToId: Record<string, { id: number, riskRatingIucnId: number }>, iucnCodeToId: Record<string, number>): Promise<void> => {
   const speciesNames = Object.keys(speciesNameToId)
-  const [iucnSpecies, iucnSpeciesNarrative] = await Promise.all([getSequentially(speciesNames, getIucnSpecies), getSequentially(speciesNames, getIucnSpeciesNarrative)])
 
-  const newData: TaxonSpeciesIucn[] = speciesNames.map(speciesName => {
-    console.info('speciesName', speciesName)
-    const iucnSpeciesData = iucnSpecies[speciesName]
-    const iucnSpeciesNarrativeData = iucnSpeciesNarrative[speciesName]
+  // One sequential pass per species. For each species we make at most TWO IUCN
+  // calls: one `/species` lookup, then (only if it has an assessment) one
+  // `/assessment/{id}` narrative call reusing the id we already have. The old
+  // code ran two concurrent loops where the narrative loop re-fetched
+  // `/species` internally — that both doubled `/species` traffic AND halved the
+  // effective throttle (two interleaved request streams against one rate limit).
+  let batch: TaxonSpeciesIucn[] = []
+  let written = 0
+
+  const flush = async (): Promise<void> => {
+    if (batch.length === 0) return
+    await writeIucnSpeciesDataToPostgres(sequelize, batch)
+    written += batch.length
+    console.info(`- syncIucnSpeciesInfo: flushed ${batch.length} (total ${written}/${speciesNames.length})`)
+    batch = []
+  }
+
+  for (const speciesName of speciesNames) {
+    const iucnSpeciesData = await getIucnSpecies(speciesName)
+
+    const assessmentId = iucnSpeciesData?.assessments?.[0]?.assessment_id
+    const iucnSpeciesNarrativeData = assessmentId != null
+      ? await getIucnAssessmentNarrative(assessmentId, speciesName)
+      : undefined
+
     const commonName = iucnSpeciesData?.common_names?.filter(n => n.main === true) ?? ''
-    return {
+    batch.push({
       taxonSpeciesId: speciesNameToId[speciesName].id,
       commonName: commonName[0]?.name ?? '',
       riskRatingIucnId: iucnCodeToId[iucnSpeciesData?.assessments[0]?.red_list_category_code ?? ''] ?? speciesNameToId[speciesName].riskRatingIucnId ?? DEFAULT_RISK_RATING,
       description: iucnSpeciesNarrativeData?.documentation?.habitats ?? '',
       descriptionSourceUrl: iucnSpeciesNarrativeData?.sourceUrl ?? ''
-    }
-  })
+    })
 
-  await writeIucnSpeciesDataToPostgres(sequelize, newData)
+    if (batch.length >= WRITE_BATCH_SIZE) await flush()
+    await wait(REQUEST_SPACING_MS)
+  }
+
+  await flush()
 }


### PR DESCRIPTION
Develop sync of #2502 (merged to master as f50a1a7).

Keeps mainline aligned with the master-deployed fix: `getIucnAssessmentNarrative` takes the assessment id directly (no `/species` re-fetch → ~2× fewer calls), single sequential per-species pass (honest throttle, fewer 429s), batched durable writes (size 200, resumable). Behavior unchanged; test updated to mock `getIucnAssessmentNarrative` + instant `wait()`.