### PR TITLE
fix(cli): IUCN sync type error blocking CD build (TS2339 common name)

### DIFF
--- a/apps/cli/src/ingest/external/iucn.ts
+++ b/apps/cli/src/ingest/external/iucn.ts
@@ -66,10 +66,10 @@ export const syncIucnSpeciesInfo = async (sequelize: Sequelize, speciesNameToId:
       ? await getIucnAssessmentNarrative(assessmentId, speciesName)
       : undefined
 
-    const commonName = iucnSpeciesData?.common_names?.filter(n => n.main === true) ?? ''
+    const mainCommonName = iucnSpeciesData?.common_names?.find(n => n.main === true)?.name ?? ''
     batch.push({
       taxonSpeciesId: speciesNameToId[speciesName].id,
-      commonName: commonName[0]?.name ?? '',
+      commonName: mainCommonName,
       riskRatingIucnId: iucnCodeToId[iucnSpeciesData?.assessments[0]?.red_list_category_code ?? ''] ?? speciesNameToId[speciesName].riskRatingIucnId ?? DEFAULT_RISK_RATING,
       description: iucnSpeciesNarrativeData?.documentation?.habitats ?? '',
       descriptionSourceUrl: iucnSpeciesNarrativeData?.sourceUrl ?? ''


### PR DESCRIPTION
**Hotfix for the failed CD build of #2502.** The merge of #2502 broke the production CD build with:

```
apps/cli build: src/ingest/external/iucn.ts(72,34): error TS2339: Property 'name' does not exist on type 'string | CommonName'.
```

**Cause:** since the refactor sources `iucnSpeciesData` from `getIucnSpecies()` (which returns `IucnSpecies | undefined`), the original `common_names?.filter(...) ?? ''` expression produced a `CommonName[] | ''` union, so `[0]?.name` failed to typecheck on the string branch. (My local typecheck missed this due to unreliable workspace-type resolution; the real CI build caught it.)

**Fix:** `common_names?.find(n => n.main === true)?.name ?? ''` — cleanly typed as `string`, same runtime result (the main common name, or empty string).

Verified with the authoritative toolchain in a clean worktree: `pnpm --filter @rfcx-bio/cli build` (`tsc --build`) exits 0, eslint clean.

**No production impact:** the failed build meant nothing deployed — `biodiversity-cli` is still on `9340b67`. This restores a green build so the IUCN fix actually ships. Develop-sync to follow.