### PR TITLE
chore(cli): sync IUCN common-name type fix to develop (#2504)

### DIFF
--- a/apps/cli/src/ingest/external/iucn.ts
+++ b/apps/cli/src/ingest/external/iucn.ts
@@ -66,10 +66,10 @@ export const syncIucnSpeciesInfo = async (sequelize: Sequelize, speciesNameToId:
       ? await getIucnAssessmentNarrative(assessmentId, speciesName)
       : undefined
 
-    const commonName = iucnSpeciesData?.common_names?.filter(n => n.main === true) ?? ''
+    const mainCommonName = iucnSpeciesData?.common_names?.find(n => n.main === true)?.name ?? ''
     batch.push({
       taxonSpeciesId: speciesNameToId[speciesName].id,
-      commonName: commonName[0]?.name ?? '',
+      commonName: mainCommonName,
       riskRatingIucnId: iucnCodeToId[iucnSpeciesData?.assessments[0]?.red_list_category_code ?? ''] ?? speciesNameToId[speciesName].riskRatingIucnId ?? DEFAULT_RISK_RATING,
       description: iucnSpeciesNarrativeData?.documentation?.habitats ?? '',
       descriptionSourceUrl: iucnSpeciesNarrativeData?.sourceUrl ?? ''


### PR DESCRIPTION
Develop sync of the #2504 hotfix (common-name TS2339 that blocked the #2502 CD build). `find(n => n.main)?.name ?? ''` — same runtime result, cleanly typed. Keeps develop aligned with master.