### PR TITLE
feat(audiodata): server-side whole-list sorting + page-size selector + top pager

### DIFF
--- a/apps/website/src/projects/audiodata/_composables/use-recordings.ts
+++ b/apps/website/src/projects/audiodata/_composables/use-recordings.ts
@@ -17,8 +17,8 @@ export const useRecordings = (
       return await apiArbimonGetRecordings(apiClient, slug.value, request.value ?? {
         limit: 10,
         offset: 0,
-        output: ['count', 'date_range', 'list'],
-        sortBy: 'r.site_id DESC, r.datetime DESC'
+        output: ['count', 'date_range', 'list']
+        // No sortBy => backend default order (site_id DESC, datetime DESC).
       })
     },
     staleTime: 1000 * 60 * 5,

--- a/apps/website/src/projects/audiodata/component/page-size-selector.vue
+++ b/apps/website/src/projects/audiodata/component/page-size-selector.vue
@@ -1,0 +1,42 @@
+<template>
+  <div class="inline-flex items-center gap-2">
+    <span
+      v-if="label"
+      class="text-xs font-bold text-white"
+    >{{ label }}</span>
+    <div class="inline-flex border border-util-gray-03 rounded overflow-hidden">
+      <button
+        v-for="option in options"
+        :key="option"
+        :class="[
+          'px-[10px] py-[5px] text-xs border-l font-bold border-util-gray-03 first:border-l-0',
+          modelValue === option
+            ? 'bg-util-gray-03 text-white'
+            : 'hover:bg-util-gray-04 text-white',
+        ]"
+        @click="select(option)"
+      >
+        {{ option }}
+      </button>
+    </div>
+  </div>
+</template>
+
+<script setup lang="ts">
+const props = withDefaults(defineProps<{
+  modelValue: number
+  options?: number[]
+  label?: string
+}>(), {
+  options: () => [10, 25, 50, 100],
+  label: ''
+})
+
+const emit = defineEmits<{(e: 'update:modelValue', value: number): void }>()
+
+const select = (value: number): void => {
+  if (value !== props.modelValue) {
+    emit('update:modelValue', value)
+  }
+}
+</script>

--- a/apps/website/src/projects/audiodata/component/sortable-table.vue
+++ b/apps/website/src/projects/audiodata/component/sortable-table.vue
@@ -28,7 +28,9 @@
             v-for="column in columns"
             :key="column.key"
             :style="`max-width: ${column.maxWidth || 100}px`"
-            class="px-2 pb-2 cursor-pointer border-b-2 border-b-util-gray-03 align-bottom"
+            class="px-2 pb-2 border-b-2 border-b-util-gray-03 align-bottom"
+            :class="isSortable(column) ? 'cursor-pointer' : 'cursor-default'"
+            :aria-sort="sortKey === column.key ? (sortOrder === 'asc' ? 'ascending' : 'descending') : undefined"
             @click="sortBy(column.key)"
           >
             <span
@@ -41,7 +43,7 @@
                 {{ column.label }}
               </span>
               <span
-                v-if="sortKey === column.key"
+                v-if="isSortable(column) && sortKey === column.key"
                 class="ml-1 shrink-0 inline-block transform"
                 :class="sortOrder === 'asc' ? 'rotate-270' : 'rotate-90'"
               >
@@ -281,6 +283,10 @@ interface Column {
   label: string
   key: string
   maxWidth: number
+  // Columns are sortable by default. Set `sortable: false` to make a column
+  // (e.g. free-text Notes/comments) non-sortable: no pointer cursor, no
+  // click handler, no sort arrow.
+  sortable?: boolean
 }
 
 export interface Row {
@@ -327,9 +333,19 @@ const props = defineProps<{
   nonRounded?: boolean
   textSize?: string
   addingTemplateId?: number | null
+  // When true, the table is "controlled": header clicks emit `sort` and the
+  // parent is responsible for re-querying the full (server-paged) dataset in
+  // the requested order. Rows are rendered in the order received. When false
+  // (default), the table sorts the rows it was given client-side — correct
+  // only for lists that are fully loaded in the browser.
+  serverSort?: boolean
 }>()
 
-const emit = defineEmits<{(e: 'selectedItem', row?: Row): void, (e: 'selectedRows', rows?: Row[]): void, (e: 'onAddTemplates', request: TemplateRequest, tplId?: number): void, (e: 'onPlaySoundError'): void}>()
+const emit = defineEmits<{(e: 'selectedItem', row?: Row): void, (e: 'selectedRows', rows?: Row[]): void, (e: 'onAddTemplates', request: TemplateRequest, tplId?: number): void, (e: 'onPlaySoundError'): void, (e: 'sort', payload: { key: string, order: 'asc' | 'desc' }): void}>()
+
+function isSortable (column: Column): boolean {
+  return column.sortable !== false
+}
 
 const sortKey = ref<string | null>(null)
 const sortOrder = ref<'asc' | 'desc'>('asc')
@@ -477,18 +493,27 @@ const isEmptyTemplateList = (key: string, row: Row): boolean => {
 }
 
 const sortBy = (key: string) => {
+  const column = props.columns.find(c => c.key === key)
+  if (column && !isSortable(column)) return
+
   if (sortKey.value === key) {
     sortOrder.value = sortOrder.value === 'asc' ? 'desc' : 'asc'
   } else {
     sortKey.value = key
     sortOrder.value = 'asc'
   }
+
+  if (props.serverSort) {
+    emit('sort', { key, order: sortOrder.value })
+  }
 }
 const sortedRows = computed<Row[]>(() => {
   const rows = toRaw(props.rows)
   const list = Array.isArray(rows) ? [...rows] : []
 
-  if (!sortKey.value) {
+  // In controlled/server-sort mode the parent already returns rows in the
+  // requested order for the whole dataset; never re-sort the current page.
+  if (props.serverSort || !sortKey.value) {
     return list
   }
 

--- a/apps/website/src/projects/audiodata/recordings-page.vue
+++ b/apps/website/src/projects/audiodata/recordings-page.vue
@@ -202,6 +202,14 @@
         </div>
       </div>
 
+      <PaginationComponent
+        v-show="!isLoadingRecordings && !(recordingsCount === 0) && !isErrorRecordings && !isRefetchRecordings"
+        class="mb-4"
+        :current-page="currentPage"
+        :total-pages="totalPages"
+        @update:current-page="handlePageChange"
+      />
+
       <SortableTable
         v-show="!isLoadingRecordings && !isRefetchRecordings"
         class="mt-5"
@@ -209,11 +217,11 @@
         :rows="filteredRecordings ?? []"
         :selected-row="selectedRecording"
         :selected-items="selectedRows"
-        :default-sort-key="'updated_at'"
-        :default-sort-order="'desc'"
+        :server-sort="true"
         :project-slug="selectedProjectSlug"
         :show-expand="true"
         :show-checkbox="true"
+        @sort="onSort"
         @selected-rows="onSelectedRecordings"
       />
     </div>
@@ -291,11 +299,19 @@ const limitOptions = [10, 25, 50, 100]
 
 const selectedRows = ref<Row[]>([])
 const filterParams = ref<RecordingSearchParams>()
+// Server-side sort state. `sortKey` is a whitelisted column key understood
+// by the arbimon-legacy recordings/search endpoint (site|datetime|filename|
+// upload_time|recorder). `undefined` => backend default (site_id DESC,
+// datetime DESC). `sortRev=true` => DESC.
+const sortKey = ref<string | undefined>(undefined)
+const sortRev = ref<boolean>(true)
+
 const requestParams = computed<RecordingSearchParams>(() => ({
   limit: limitPerPage.value,
   offset: offset.value,
   output: ['count', 'date_range', 'list'],
-  sortBy: 'r.site_id DESC, r.datetime DESC',
+  sortBy: sortKey.value,
+  sortRev: sortRev.value,
   presence: filterParams.value?.presence,
   playlists: filterParams.value?.playlists,
   range: filterParams.value?.range,
@@ -317,7 +333,7 @@ const requestParams = computed<RecordingSearchParams>(() => ({
 }))
 
 const requestParamsForPlaylist = computed(() => {
-  const { limit, offset, output, sortBy, ...rest } = requestParams.value
+  const { limit, offset, output, sortBy, sortRev, ...rest } = requestParams.value
   return rest
 })
 
@@ -333,7 +349,7 @@ const requestParamsForExport = computed(() => {
 })
 
 const requestParamsForSearchCount = computed(() => {
-  const { limit, offset, output, sortBy, recIds, ...rest } = requestParams.value
+  const { limit, offset, output, sortBy, sortRev, recIds, ...rest } = requestParams.value
   return rest
 })
 
@@ -449,8 +465,17 @@ const columns = [
   { label: 'Filename', key: 'filename', maxWidth: 90 },
   { label: 'Uploaded', key: 'upload_time', maxWidth: 70 },
   { label: 'Recorder', key: 'recorder', maxWidth: 70 },
-  { label: 'Notes', key: 'comments', maxWidth: 150 }
+  // Free-text notes/comments are not a sortable DB column.
+  { label: 'Notes', key: 'comments', maxWidth: 150, sortable: false }
 ]
+
+// Re-sort the ENTIRE filtered dataset server-side and jump back to page 1.
+const onSort = async (payload: { key: string, order: 'asc' | 'desc' }) => {
+  sortKey.value = payload.key
+  sortRev.value = payload.order === 'desc'
+  currentPage.value = 1
+  await refetchRecordings()
+}
 const selectedRecording = ref<RecordingSearchResponse | undefined>(undefined)
 
 const filteredRecordings = computed(() => {
@@ -513,6 +538,7 @@ const clearSelectedRows = async () => {
 
 const changeLimit = async (value: number) => {
   limitPerPage.value = value
+  currentPage.value = 1
   await refetchRecordings()
 }
 

--- a/apps/website/src/projects/audiodata/species-page.vue
+++ b/apps/website/src/projects/audiodata/species-page.vue
@@ -119,6 +119,22 @@
       </span>
     </div>
     <div
+      v-show="!isLoadingSpecies && !isRefetchSpecies && !isLoadingProjectTemplates && !isLoadingPublicTemplates && speciesCount !== 0"
+      class="flex items-center justify-between mt-5 px-9"
+    >
+      <PageSizeSelector
+        v-model="limitPerPage"
+        label="Per page"
+      />
+      <PaginationComponent
+        v-show="(initialSpeciesCount ?? 0) > limitPerPage"
+        :current-page="currentPage"
+        :total-pages="totalPages"
+        :hide-jump-page="true"
+        @update:current-page="handlePageChange"
+      />
+    </div>
+    <div
       v-show="!isLoadingSpecies && !isRefetchSpecies && !isLoadingProjectTemplates && !isLoadingPublicTemplates"
       class="flex mt-3 px-9"
     >
@@ -130,10 +146,11 @@
         :selected-items="selectedRows"
         :project-slug="selectedProjectSlug"
         :project-templates="speciesProjectTemplates"
-        :default-sort-order="'desc'"
+        :server-sort="true"
         :show-checkbox="true"
         :template-added-id="templateAddedId"
         :adding-template-id="addingTemplateId"
+        @sort="onSort"
         @on-add-templates="onAddTemplates"
         @selected-rows="onSelectedSpecies"
         @on-play-sound-error="onPlaySoundError"
@@ -158,7 +175,7 @@
     </div>
     <div class="flex mt-3">
       <PaginationComponent
-        v-show="!isLoadingSpecies && !(speciesCount === 0) && !isErrorSpecies && !isRefetchSpecies && !isLoadingProjectTemplates && !isLoadingPublicTemplates && (initialSpeciesCount ?? 0) > LIMIT"
+        v-show="!isLoadingSpecies && !(speciesCount === 0) && !isErrorSpecies && !isRefetchSpecies && !isLoadingProjectTemplates && !isLoadingPublicTemplates && (initialSpeciesCount ?? 0) > limitPerPage"
         class="mt-4 px-8"
         :current-page="currentPage"
         :total-pages="totalPages"
@@ -215,6 +232,7 @@ import { useGetProjectTemplates, useGetPublicTemplates, useGetSpecies } from './
 import CreateSpecies from './component/create-species.vue'
 import CustomPopup from './component/custom-popup.vue'
 import ImportSpecies from './component/import-species.vue'
+import PageSizeSelector from './component/page-size-selector.vue'
 import PaginationComponent from './component/pagination-component.vue'
 import SortableTable from './component/sortable-table.vue'
 import { type Row } from './component/sortable-table.vue'
@@ -227,14 +245,21 @@ const createSpecies = ref<InstanceType<typeof CreateSpecies> | null>(null)
 const searchKeyword = ref('')
 const searchTimeout = ref<number | undefined>(undefined)
 
-const LIMIT = 10
+const limitPerPage = ref(10)
 const currentPage = ref(1)
 
-const offset = computed(() => (currentPage.value - 1) * LIMIT)
+// Server-side sort state. `sortKey` is a whitelisted column key understood by
+// the arbimon-legacy /classes endpoint (species_name|taxon|songtype_name).
+const sortKey = ref<string | undefined>(undefined)
+const sortRev = ref<boolean>(false)
+
+const offset = computed(() => (currentPage.value - 1) * limitPerPage.value)
 const speciesParams = computed<SpeciesClassesParams>(() => ({
-    limit: LIMIT,
+    limit: limitPerPage.value,
     offset: offset.value,
-    q: searchKeyword.value
+    q: searchKeyword.value,
+    sortBy: sortKey.value,
+    sortRev: sortRev.value
 }))
 
 const apiClientArbimon = inject(apiClientArbimonLegacyKey) as AxiosInstance
@@ -264,11 +289,13 @@ watch(
 
 const columns = [
   { label: 'Species', key: 'species_name', maxWidth: 90 },
-  { label: 'Also known as', key: 'aliases', maxWidth: 120 },
+  // 'Also known as' is a computed alias list, not a single sortable DB column.
+  { label: 'Also known as', key: 'aliases', maxWidth: 120, sortable: false },
   { label: 'Taxon', key: 'taxon', maxWidth: 70 },
   { label: 'Sound', key: 'songtype_name', maxWidth: 70 },
-  { label: 'Project Templates', key: 'project_templates', maxWidth: 150 },
-  { label: 'Public Templates', key: 'public_templates', maxWidth: 150 }
+  // Template columns render thumbnail grids, not a sortable scalar value.
+  { label: 'Project Templates', key: 'project_templates', maxWidth: 150, sortable: false },
+  { label: 'Public Templates', key: 'public_templates', maxWidth: 150, sortable: false }
 ]
 
 const selectedRows = ref<Row[]>([])
@@ -277,13 +304,27 @@ const speciesCount = computed(() => { return speciesData.value?.count ?? 0 })
 const speciesCountText = computed<string>(() =>
   new Intl.NumberFormat('en-US').format(speciesCount.value)
 )
-const totalPages = computed(() => Math.ceil(speciesCount.value / LIMIT))
+const totalPages = computed(() => Math.ceil(speciesCount.value / limitPerPage.value))
 
 const handlePageChange = async (page: number) => {
   if (currentPage.value === page) return
   currentPage.value = page
   await refetchSpecies()
 }
+
+// Re-sort the ENTIRE species list server-side and jump back to page 1.
+const onSort = async (payload: { key: string, order: 'asc' | 'desc' }) => {
+  sortKey.value = payload.key
+  sortRev.value = payload.order === 'desc'
+  currentPage.value = 1
+  await refetchSpecies()
+}
+
+// Changing page size resets to page 1.
+watch(limitPerPage, async () => {
+  currentPage.value = 1
+  await refetchSpecies()
+})
 
 const selectedSpecies = ref<SpeciesType | undefined>(undefined)
 const showPopup = ref(false)

--- a/packages/common/src/api-arbimon/audiodata/recording.ts
+++ b/packages/common/src/api-arbimon/audiodata/recording.ts
@@ -4,7 +4,11 @@ export interface RecordingSearchParams {
   limit?: number
   offset?: number
   output?: Array<'count' | 'date_range' | 'list'>
+  // Whitelisted server-side sort key (arbimon-legacy recordings/search):
+  // site | datetime | filename | upload_time | recorder. Omit for the
+  // backend default (site_id DESC, datetime DESC).
   sortBy?: string
+  sortRev?: boolean
   playlists?: number[]
   range?: string
   sites?: string[]
@@ -57,6 +61,7 @@ function buildRecordingSearchQuery (params: RecordingSearchParams): URLSearchPar
   if (params.limit !== undefined) searchParams.append('limit', String(params.limit))
   if (params.offset !== undefined) searchParams.append('offset', String(params.offset))
   if (params.sortBy) searchParams.append('sortBy', params.sortBy)
+  if (params.sortRev !== undefined) searchParams.append('sortRev', String(params.sortRev))
   if (params.range) searchParams.append('range', params.range)
 
   appendArray('output', params.output)

--- a/packages/common/src/api-arbimon/audiodata/species.ts
+++ b/packages/common/src/api-arbimon/audiodata/species.ts
@@ -23,6 +23,10 @@ export interface SpeciesClassesParams {
   limit: number
   offset: number
   q: string
+  // Whitelisted server-side sort (arbimon-legacy /classes): one of
+  // species_name | taxon | songtype_name. Omit for default ordering.
+  sortBy?: string
+  sortRev?: boolean
 }
 
 export const apiArbimonGetSpeciesClasses = async (apiClient: AxiosInstance, slug: string, params: SpeciesClassesParams): Promise<SpeciesResponse[] | undefined> => {


### PR DESCRIPTION
Makes column-header sorting re-order the **entire** list (not just the current page) on the audiodata pages, plus pagination UX. Paired with **rfcx/arbimon-legacy#1733** (API). Targets **master** directly (production runs master HEAD; clean cherry-pick of the develop work — all touched files are identical across master/develop).

## Problem
Clicking a column header on e.g. `/p/<slug>/audiodata/recordings` only re-ordered the rows on the current page. `SortableTable` sorted its own `props.rows` client-side and never told the parent to re-query; recordings hardcoded the server sort.

## Changes
**`SortableTable` (shared):** opt-in `serverSort` controlled mode (emits `sort {key, order}`, renders server order, never re-sorts current page); per-column `sortable` flag (default true; non-sortable = no cursor/handler/arrow); `aria-sort`.
**Recordings** (server-paged): server sort via whitelisted keys (`site|datetime|filename|upload_time|recorder`); Notes/comments non-sortable; re-sort + page-size change reset to page 1; **duplicate pager above table**.
**Species** (server-paged): server sort (`species_name|taxon|songtype_name`; template/alias cols non-sortable); **page-size selector (10/25/50/100, default 10)** + top pager; reactive `limitPerPage`.
**New shared `PageSizeSelector`**. API types: `sortRev` on `RecordingSearchParams`; `sortBy`/`sortRev` on `SpeciesClassesParams`.
**Sites + create-species** load full datasets client-side → already whole-list; inherit non-sortable-column support.

## Operator asks
1. ✅ entire list re-sorts (all `sortable-table.vue` call sites) 2. ✅ comments non-sortable 3. ✅ reset to page 1 4. ✅ size selector 10/25/50/100 5. ✅ duplicate top pager.

## Verification
`vue-tsc`: no new errors (only a pre-existing untouched `dayjs.tz` typing issue behind `--skipLibCheck`). ESLint: 0 errors on changed files.

## Deploy
Layer-A; master CD rolls `biodiversity-website`/`-api`. **Merge AFTER arbimon-legacy#1733.**

🤖 agent session (ms4); see rfcx-local runbooks/ACTIVE-SESSIONS.md.