### PR TITLE
fix(audiodata): Recorder non-sortable + left-justified pagination with inline count

### DIFF
--- a/apps/website/src/projects/audiodata/recordings-page.vue
+++ b/apps/website/src/projects/audiodata/recordings-page.vue
@@ -166,16 +166,22 @@
       class="mt-4 px-8"
     >
       <div class="flex justify-between items-center mb-4">
-        <div class="inline-block flex">
-          <span class="ml-1 font-bold text-left text-sm leading-[26px] inline-block align-middle text-white">
+        <div class="flex items-center flex-wrap gap-x-4 gap-y-2">
+          <span class="ml-1 font-bold text-left text-sm leading-[26px] inline-block align-middle text-white whitespace-nowrap">
             {{ recordingsCountText }} {{ recordingsCount > 1 ? "Recordings" : "Recording" }}
           </span>
           <div
             v-show="filterParams !== undefined"
-            class="px-2 py-1 bg-util-gray-04 text-sm ml-2 rounded-[3px] font-medium"
+            class="px-2 py-1 bg-util-gray-04 text-sm rounded-[3px] font-medium"
           >
             Filters applied
           </div>
+          <PaginationComponent
+            v-show="!isLoadingRecordings && !(recordingsCount === 0) && !isErrorRecordings && !isRefetchRecordings"
+            :current-page="currentPage"
+            :total-pages="totalPages"
+            @update:current-page="handlePageChange"
+          />
         </div>
         <div class="flex items-center">
           <div class="inline-flex border border-util-gray-03 rounded overflow-hidden">
@@ -201,14 +207,6 @@
           </button>
         </div>
       </div>
-
-      <PaginationComponent
-        v-show="!isLoadingRecordings && !(recordingsCount === 0) && !isErrorRecordings && !isRefetchRecordings"
-        class="mb-4"
-        :current-page="currentPage"
-        :total-pages="totalPages"
-        @update:current-page="handlePageChange"
-      />
 
       <SortableTable
         v-show="!isLoadingRecordings && !isRefetchRecordings"

--- a/apps/website/src/projects/audiodata/recordings-page.vue
+++ b/apps/website/src/projects/audiodata/recordings-page.vue
@@ -464,7 +464,9 @@ const columns = [
   { label: 'Recorded Time', key: 'datetime', maxWidth: 110 },
   { label: 'Filename', key: 'filename', maxWidth: 90 },
   { label: 'Uploaded', key: 'upload_time', maxWidth: 70 },
-  { label: 'Recorder', key: 'recorder', maxWidth: 70 },
+  // Recorder has no (site_id, recorder) composite index on the ~273M-row
+  // recordings table, so a project-wide sort would full-scan/time out.
+  { label: 'Recorder', key: 'recorder', maxWidth: 70, sortable: false },
   // Free-text notes/comments are not a sortable DB column.
   { label: 'Notes', key: 'comments', maxWidth: 150, sortable: false }
 ]


### PR DESCRIPTION
Frontend pair to **rfcx/arbimon-legacy#1734**. Two changes to the recordings page.

## 1. Recorder column non-sortable
Per ops decision, sortable columns are **Site / Recorded Time / Filename / Uploaded**. Recorder has no `(site_id, recorder)` composite index on the ~273M-row recordings table, so a project-wide sort would full-scan/timeout. Marked `sortable: false` → no arrow, no pointer cursor, clicks ignored. (Notes was already non-sortable.)

## 2. Pagination layout
Per ops feedback: the top pagination bar now sits on the **same line** as the "X Recordings" count (+ "Filters applied" badge), **left-justified**. Page-size selector (10/25/50/100) + refresh stay right-aligned; bottom pager unchanged.

Backend (#1734) is already merged + deployed; the API now sorts Filename by the displayed `meta.filename` value (virtual column + index) and falls back safely. Lint/typecheck clean.

🤖 agent session (ms4).