### PR TITLE
feat(audiodata): unified list controls bar (count+range / pager+size) above & below recordings

### DIFF
--- a/apps/website/src/projects/audiodata/component/list-controls-bar.vue
+++ b/apps/website/src/projects/audiodata/component/list-controls-bar.vue
@@ -1,0 +1,89 @@
+<template>
+  <div class="flex justify-between items-center gap-x-4 gap-y-2 flex-wrap">
+    <!-- Left: count + currently-displaying range, left-justified -->
+    <div class="flex items-center flex-wrap gap-x-3 gap-y-1">
+      <span class="ml-1 font-bold text-left text-sm leading-[26px] text-white whitespace-nowrap">
+        {{ rangeText }}
+      </span>
+      <div
+        v-if="showFiltersApplied"
+        class="px-2 py-1 bg-util-gray-04 text-sm rounded-[3px] font-medium"
+      >
+        Filters applied
+      </div>
+    </div>
+
+    <!-- Right: pagination + page-size + refresh, horizontally stacked, right-justified -->
+    <div class="flex items-center gap-x-3 flex-wrap justify-end">
+      <PaginationComponent
+        v-if="totalPages > 0"
+        :current-page="currentPage"
+        :total-pages="totalPages"
+        @update:current-page="onPageChange"
+      />
+      <div class="inline-flex border border-util-gray-03 rounded overflow-hidden">
+        <button
+          v-for="option in limitOptions"
+          :key="option"
+          :class="[
+            'px-[10px] py-[5px] text-xs border-l font-bold border-util-gray-03 first:border-l-0',
+            limitPerPage === option
+              ? 'bg-util-gray-03 text-white'
+              : 'hover:bg-util-gray-04 text-white',
+          ]"
+          @click="emit('update:limitPerPage', option)"
+        >
+          {{ option }}
+        </button>
+      </div>
+      <button
+        v-if="showRefresh"
+        class="px-[10px] py-[5px] text-xs text-white border border-util-gray-03 rounded hover:bg-util-gray-04 transition"
+        title="Refresh"
+        @click="emit('refresh')"
+      >
+        <icon-fa-refresh class="w-[10px]" />
+      </button>
+    </div>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { computed } from 'vue'
+
+import PaginationComponent from './pagination-component.vue'
+
+const props = withDefaults(defineProps<{
+  totalCount: number
+  currentPage: number
+  totalPages: number
+  limitPerPage: number
+  limitOptions?: number[]
+  noun?: string
+  pluralNoun?: string
+  showFiltersApplied?: boolean
+  showRefresh?: boolean
+}>(), {
+  limitOptions: () => [10, 25, 50, 100],
+  noun: 'Recording',
+  pluralNoun: 'Recordings',
+  showFiltersApplied: false,
+  showRefresh: false
+})
+
+const emit = defineEmits<{(e: 'update:currentPage', value: number): void, (e: 'update:limitPerPage', value: number): void, (e: 'refresh'): void }>()
+
+const onPageChange = (p: number): void => emit('update:currentPage', p)
+
+const fmt = (n: number): string => new Intl.NumberFormat('en-US').format(n)
+
+// "11-20 of 100,000 Recordings" (or "1 Recording", "0 Recordings")
+const rangeText = computed<string>(() => {
+  const total = props.totalCount
+  const noun = total === 1 ? props.noun : props.pluralNoun
+  if (total <= 0) return `0 ${props.pluralNoun}`
+  const start = (props.currentPage - 1) * props.limitPerPage + 1
+  const end = Math.min(props.currentPage * props.limitPerPage, total)
+  return `${fmt(start)}-${fmt(end)} of ${fmt(total)} ${noun}`
+})
+</script>

--- a/apps/website/src/projects/audiodata/recordings-page.vue
+++ b/apps/website/src/projects/audiodata/recordings-page.vue
@@ -165,48 +165,19 @@
       v-show="!isLoadingRecordings && !isRefetchRecordings"
       class="mt-4 px-8"
     >
-      <div class="flex justify-between items-center mb-4">
-        <div class="flex items-center flex-wrap gap-x-4 gap-y-2">
-          <span class="ml-1 font-bold text-left text-sm leading-[26px] inline-block align-middle text-white whitespace-nowrap">
-            {{ recordingsCountText }} {{ recordingsCount > 1 ? "Recordings" : "Recording" }}
-          </span>
-          <div
-            v-show="filterParams !== undefined"
-            class="px-2 py-1 bg-util-gray-04 text-sm rounded-[3px] font-medium"
-          >
-            Filters applied
-          </div>
-          <PaginationComponent
-            v-show="!isLoadingRecordings && !(recordingsCount === 0) && !isErrorRecordings && !isRefetchRecordings"
-            :current-page="currentPage"
-            :total-pages="totalPages"
-            @update:current-page="handlePageChange"
-          />
-        </div>
-        <div class="flex items-center">
-          <div class="inline-flex border border-util-gray-03 rounded overflow-hidden">
-            <button
-              v-for="(option) in limitOptions"
-              :key="option"
-              :class="[
-                'px-[10px] py-[5px] text-xs border-l font-bold border-util-gray-03 first:border-l-0',
-                limitPerPage === option
-                  ? 'bg-util-gray-03 text-white'
-                  : 'hover:bg-util-gray-04 text-white',
-              ]"
-              @click="changeLimit(option)"
-            >
-              {{ option }}
-            </button>
-          </div>
-          <button
-            class="ml-3 px-[10px] py-[5px] text-xs text-white border border-util-gray-03 rounded hover:bg-util-gray-04 transition"
-            @click="applyRecordings"
-          >
-            <icon-fa-refresh class="w-[10px]" />
-          </button>
-        </div>
-      </div>
+      <ListControlsBar
+        class="mb-4"
+        :total-count="recordingsCount"
+        :current-page="currentPage"
+        :total-pages="totalPages"
+        :limit-per-page="limitPerPage"
+        :limit-options="limitOptions"
+        :show-filters-applied="filterParams !== undefined"
+        :show-refresh="true"
+        @update:current-page="handlePageChange"
+        @update:limit-per-page="changeLimit"
+        @refresh="applyRecordings"
+      />
 
       <SortableTable
         v-show="!isLoadingRecordings && !isRefetchRecordings"
@@ -230,12 +201,19 @@
       <span class="font-display">Recordings not found</span>
     </div>
 
-    <PaginationComponent
+    <ListControlsBar
       v-show="!isLoadingRecordings && !(recordingsCount === 0) && !isErrorRecordings && !isRefetchRecordings"
       class="mt-4 px-8"
+      :total-count="recordingsCount"
       :current-page="currentPage"
       :total-pages="totalPages"
+      :limit-per-page="limitPerPage"
+      :limit-options="limitOptions"
+      :show-filters-applied="filterParams !== undefined"
+      :show-refresh="true"
       @update:current-page="handlePageChange"
+      @update:limit-per-page="changeLimit"
+      @refresh="applyRecordings"
     />
     <CreatePlaylistModal
       v-if="showCreatePlaylistModal"
@@ -285,7 +263,7 @@ import CreatePlaylistModal from './component/create-playlist.vue'
 import CustomPopup from './component/custom-popup.vue'
 import ExportPanel from './component/export-panel.vue'
 import FilterPanel, { type DateTime } from './component/filter-panel.vue'
-import PaginationComponent from './component/pagination-component.vue'
+import ListControlsBar from './component/list-controls-bar.vue'
 import SortableTable from './component/sortable-table.vue'
 import { type Row } from './component/sortable-table.vue'
 
@@ -443,9 +421,6 @@ const { data: soundscapeRecordings } = useGetSoundscape(apiClientArbimon, select
 const { data: classifications } = useGetClassifications(apiClientArbimon, selectedProjectSlug)
 
 const recordingsCount = computed(() => { return recordings.value?.count ?? 0 })
-const recordingsCountText = computed<string>(() =>
-  new Intl.NumberFormat('en-US').format(recordingsCount.value)
-)
 const showCreatePlaylistModal = ref(false)
 const showExportPanel = ref(false)
 


### PR DESCRIPTION
Per ops feedback on the recordings page.

## Change
New reusable **`ListControlsBar`** rendered **both above and below** the recordings table, each with the same 3 elements:
- **Left, left-justified:** count including the current page range — e.g. **"11-20 of 100,000 Recordings"** (handles singular/0 + en-US grouping).
- **Right, right-justified, horizontally stacked:** pagination controls → page-size selector (10/25/50/100) → refresh.

Replaces the old asymmetric top row (count+pager left / size+refresh right) and the standalone bottom pager. Both bars are fully wired (page change, page-size change → reset to page 1, refresh).

## Default sort
No change needed — confirmed the default `ORDER BY site_id DESC, datetime DESC` is index-backed by `recordings_site_datetime_idx` (`Using index`, no filesort, ~29ms on the gibbons project). So we keep the existing default rather than switching to recorded-at ASC.

Lint + vue-tsc clean (only pre-existing unrelated warnings).

🤖 agent session (ms4).