### PR TITLE
feat(audiodata): Jump-to dropdown lists pagination group starts

### DIFF
--- a/apps/website/src/projects/audiodata/component/pagination-component.vue
+++ b/apps/website/src/projects/audiodata/component/pagination-component.vue
@@ -60,12 +60,12 @@
     >
       <label class="ml-4 font-bold text-sm">Jump to:</label>
       <select
-        :value="currentPage"
+        :value="startPage"
         class="w-20 px-2 py-1 ml-1 bg-black border border-util-gray-03 rounded text-sm focus:border-util-gray-03 focus:outline-none focus:shadow-none focus:ring-0 focus:ring-offset-0"
         @change="onJumpSelect"
       >
         <option
-          v-for="page in totalPages"
+          v-for="page in groupStartPages"
           :key="page"
           :value="page"
         >
@@ -111,6 +111,14 @@ const endPage = computed(() => {
 const visiblePages = computed(() => {
   const pages: number[] = []
   for (let i = startPage.value; i <= endPage.value; i++) {
+    pages.push(i)
+  }
+  return pages
+})
+
+const groupStartPages = computed(() => {
+  const pages: number[] = []
+  for (let i = 1; i <= props.totalPages; i += maxPagesToShow) {
     pages.push(i)
   }
   return pages


### PR DESCRIPTION
Per ops feedback: the 'Jump to:' dropdown now lists only the start page of each pagination group instead of every page.

- Group size 10 → 1, 11, 21, 31, … up to the list limit
- Group size 25 → 1, 26, 51, 76, 101, …

The select reflects the current group via `startPage`; selecting an entry jumps to that page. New `groupStartPages` computed drives the options.

Lint + vue-tsc clean. Species page unaffected (passes `hide-jump-page`).