### PR TITLE
feat(cli): RFCx-curated fields on publication (260629-02)

### DIFF
--- a/apps/cli/src/db/migrations/260629-02-add-curatorial-fields-to-publication.ts
+++ b/apps/cli/src/db/migrations/260629-02-add-curatorial-fields-to-publication.ts
@@ -1,0 +1,34 @@
+import { type QueryInterface } from 'sequelize'
+import { type MigrationFn } from 'umzug'
+
+const PUBLICATION_TABLE = 'publication'
+
+export const up: MigrationFn<QueryInterface> = async ({ context }) => {
+  await context.sequelize.query(`
+    ALTER TABLE "${PUBLICATION_TABLE}"
+      ADD COLUMN IF NOT EXISTS is_rfcx_authored BOOLEAN NOT NULL DEFAULT FALSE,
+      ADD COLUMN IF NOT EXISTS rfcx_curated_uses TEXT,
+      ADD COLUMN IF NOT EXISTS sheet_mention_type VARCHAR(32),
+      ADD COLUMN IF NOT EXISTS in_rfcx_curated_list BOOLEAN NOT NULL DEFAULT FALSE;
+  `)
+
+  await context.sequelize.query(`
+    COMMENT ON COLUMN "${PUBLICATION_TABLE}".is_rfcx_authored IS 'Authored/co-authored by an RFCx/Arbimon team member (from the RFCx-curated publications list).';
+    COMMENT ON COLUMN "${PUBLICATION_TABLE}".rfcx_curated_uses IS 'Human-curated description of how the paper used the platform, e.g. "Arbimon (storage, PM, RFM)", "LG recorders". From the RFCx publications spreadsheet; authoritative over inferred technique tags.';
+    COMMENT ON COLUMN "${PUBLICATION_TABLE}".sheet_mention_type IS 'RFCx-curated relationship class: Use / Mention / Co-author.';
+    COMMENT ON COLUMN "${PUBLICATION_TABLE}".in_rfcx_curated_list IS 'Present in the hand-curated RFCx publications list (the legacy Google Sheet that /landing/publications used).';
+  `)
+
+  await context.sequelize.query(`CREATE INDEX IF NOT EXISTS publication_rfcx_authored_idx ON "${PUBLICATION_TABLE}" (is_rfcx_authored) WHERE is_rfcx_authored;`)
+  await context.sequelize.query(`CREATE INDEX IF NOT EXISTS publication_rfcx_curated_idx ON "${PUBLICATION_TABLE}" (in_rfcx_curated_list) WHERE in_rfcx_curated_list;`)
+}
+
+export const down: MigrationFn<QueryInterface> = async ({ context }) => {
+  await context.sequelize.query(`
+    ALTER TABLE "${PUBLICATION_TABLE}"
+      DROP COLUMN IF EXISTS in_rfcx_curated_list,
+      DROP COLUMN IF EXISTS sheet_mention_type,
+      DROP COLUMN IF EXISTS rfcx_curated_uses,
+      DROP COLUMN IF EXISTS is_rfcx_authored;
+  `)
+}


### PR DESCRIPTION
Adds curatorial columns to `publication` sourced from the hand-maintained RFCx publications list (the legacy Google Sheet that `/landing/publications` currently reads):

- `is_rfcx_authored` (BOOLEAN) — authored/co-authored by an RFCx/Arbimon team member
- `rfcx_curated_uses` (TEXT) — human description of how the paper used the platform, e.g. `Arbimon (storage, PM, RFM)`, `LG recorders` — **authoritative over our regex-inferred technique tags**
- `sheet_mention_type` (VARCHAR) — Use / Mention / Co-author
- `in_rfcx_curated_list` (BOOLEAN) — present in the curated list

+ partial indexes on the booleans. Follows 260629-01 conventions (raw SQL, IF NOT EXISTS, comments, full down()). tsc(build) 0 errors + eslint clean.

Context: scanning the legacy Google Sheet vs the new `publication` table found 23 papers missing from our corpus (ingested separately) + these per-row curatorial fields the sheet carried that our schema lacked. Data backfill (100 rows) runs after this lands. No UI yet.