### PR TITLE
feat(api): publications endpoints backed by the publication DB

### DIFF
--- a/apps/api/src/app.ts
+++ b/apps/api/src/app.ts
@@ -21,6 +21,7 @@ import { routesHealthCheck } from './healthcheck'
 import { routesLanding } from './landing'
 import { routesOrganizations } from './organizations'
 import { routesProject } from './projects'
+import { routesPublications } from './publications'
 import { routesRichness } from './richness'
 import { routesSearch } from './search'
 import { routesSpecies } from './species'
@@ -54,6 +55,7 @@ export const createApp = async (): Promise<FastifyInstance> => {
     routesDashboard,
     routesDetect,
     routesLanding,
+    routesPublications,
     routesOrganizations,
     routesProject,
     routesRichness,

--- a/apps/api/src/landing/publications/landing-publications-bll.ts
+++ b/apps/api/src/landing/publications/landing-publications-bll.ts
@@ -1,50 +1,58 @@
-import axios from 'axios'
+import { QueryTypes } from 'sequelize'
 
 import { type LandingPublicationsResponse, type Publication } from '@rfcx-bio/common/api-bio/landing/landing-publications'
 
-import { unpackAxiosError } from '~/api-helpers/axios-errors'
-import { env } from '~/env'
+import { getSequelize } from '~/db'
 
-// INFO: https://developers.google.com/sheets/api/reference/rest/v4/spreadsheets.values
-interface GoogleSheetsResponse {
-  range: string
-  majorDimension: 'ROWS' | 'COLUMNS'
-  values: string[][]
+// Backed by the `publication` table in the insights DB (replaces the legacy
+// hand-maintained Google Sheet). Returns the RFCx-curated subset to preserve
+// the original endpoint's "publications using RFCx/Arbimon" semantics + shape.
+interface PublicationRow {
+  type: string | null
+  author: string | null
+  year: number | null
+  title: string
+  journal: string | null
+  doiUrl: string | null
+  isRfcxAuthor: boolean
+  orgMention: string | null
+  uses: string | null
+  citations: number | null
 }
 
 export const getPublications = async (): Promise<LandingPublicationsResponse> => {
-  const apiKey = env.GOOGLE_SPREADSHEET_API_KEY
-  if (apiKey === undefined) {
-    return [{ type: 'Use', author: '', year: 2023, title: 'Missing API key', journal: '', doiUrl: '', isRFCxAuthor: true, orgMention: '', uses: '', citations: 0 }]
-  }
+  const sequelize = getSequelize()
 
-  // TODO: Use actual sheet
-  const spreadsheetId = '10jeiNtSLxa3yoox-_T3nH_LI0-1M4KyPMck0527Jcic'
-  const range = 'A:J'
+  const rows = await sequelize.query(
+    `SELECT
+        COALESCE(sheet_mention_type, 'Use') AS "type",
+        COALESCE(author_display, '') AS author,
+        publication_year AS "year",
+        title,
+        COALESCE(venue, '') AS journal,
+        CASE WHEN doi IS NOT NULL THEN 'https://doi.org/' || doi ELSE COALESCE(url, '') END AS "doiUrl",
+        is_rfcx_authored AS "isRfcxAuthor",
+        COALESCE(rfcx_curated_uses, '') AS "orgMention",
+        COALESCE(rfcx_curated_uses, '') AS uses,
+        COALESCE(cited_by_count, 0) AS citations
+     FROM publication
+     WHERE in_rfcx_curated_list = TRUE
+       AND is_visible = TRUE
+       AND review_status = 'approved'
+     ORDER BY publication_year DESC NULLS LAST, lower(title) ASC`,
+    { type: QueryTypes.SELECT }
+  ) as unknown as PublicationRow[]
 
-  try {
-    const response = await axios.get<GoogleSheetsResponse>(`https://sheets.googleapis.com/v4/spreadsheets/${spreadsheetId}/values/Sheet1!${range}`, {
-      headers: {
-        'x-goog-api-key': apiKey
-      }
-    })
-
-    // removes the first row that are the column names. Then start mapping
-    return response.data.values.slice(1).map(v => {
-      return {
-        type: v[0] as Publication['type'],
-        author: v[1],
-        year: Number(v[2]),
-        title: v[3],
-        journal: v[4],
-        doiUrl: v[5],
-        isRFCxAuthor: v[6].toLowerCase() === 'yes' || v[6].toLowerCase() === 'y',
-        orgMention: v[7],
-        uses: v[8],
-        citations: Number(v[9])
-      }
-    })
-  } catch (e) {
-    return unpackAxiosError(e)
-  }
+  return rows.map((r): Publication => ({
+    type: (r.type === 'Mention' || r.type === 'Co-author' ? r.type : 'Use'),
+    author: r.author ?? '',
+    year: r.year ?? 0,
+    title: r.title,
+    journal: r.journal ?? '',
+    doiUrl: r.doiUrl ?? '',
+    isRFCxAuthor: r.isRfcxAuthor,
+    orgMention: r.orgMention ?? '',
+    uses: r.uses ?? '',
+    citations: r.citations ?? 0
+  }))
 }

--- a/apps/api/src/publications/index.ts
+++ b/apps/api/src/publications/index.ts
@@ -1,0 +1,17 @@
+import { publicationsRoute, publicationTechniquesRoute } from '@rfcx-bio/common/api-bio/publications/publications'
+
+import { type RouteRegistration, GET } from '~/api-helpers/types'
+import { publicationsHandler, publicationTechniquesHandler } from './publications-handler'
+
+export const routesPublications: RouteRegistration[] = [
+  {
+    method: GET,
+    url: publicationTechniquesRoute,
+    handler: publicationTechniquesHandler
+  },
+  {
+    method: GET,
+    url: publicationsRoute,
+    handler: publicationsHandler
+  }
+]

--- a/apps/api/src/publications/publications-bll.ts
+++ b/apps/api/src/publications/publications-bll.ts
@@ -1,0 +1,27 @@
+import { type PublicationsResponse, type PublicationTechnique } from '@rfcx-bio/common/api-bio/publications/publications'
+
+import { getSequelize } from '~/db'
+import { type PublicationsFilter, countPublications, getTechniqueFacets, listPublications, listTechniques } from './publications-dao'
+
+export const getPublications = async (filter: PublicationsFilter): Promise<PublicationsResponse> => {
+  const sequelize = getSequelize()
+
+  const [total, items, techniqueFacets] = await Promise.all([
+    countPublications(sequelize, filter),
+    listPublications(sequelize, filter),
+    getTechniqueFacets(sequelize, filter)
+  ])
+
+  return {
+    total,
+    limit: filter.limit,
+    offset: filter.offset,
+    items,
+    techniqueFacets
+  }
+}
+
+export const getPublicationTechniques = async (): Promise<PublicationTechnique[]> => {
+  const sequelize = getSequelize()
+  return await listTechniques(sequelize)
+}

--- a/apps/api/src/publications/publications-dao.ts
+++ b/apps/api/src/publications/publications-dao.ts
@@ -1,0 +1,134 @@
+import { type Sequelize, QueryTypes } from 'sequelize'
+
+import { type PublicationListItem, type PublicationTechnique, type PublicationTechniqueCount } from '@rfcx-bio/common/api-bio/publications/publications'
+
+export interface PublicationsFilter {
+  search?: string
+  techniques: string[]
+  tiers: string[]
+  yearFrom?: number
+  yearTo?: number
+  rfcxAuthored: boolean
+  limit: number
+  offset: number
+  sort: 'year' | 'citations' | 'title'
+}
+
+// Build the shared WHERE clause + bind params for the filtered, visible publication set.
+const buildWhere = (filter: PublicationsFilter): { clause: string, bind: Record<string, unknown> } => {
+  const conditions: string[] = ['p.is_visible = TRUE', "p.review_status = 'approved'"]
+  const bind: Record<string, unknown> = {}
+
+  if (filter.search && filter.search.trim() !== '') {
+    bind.search = `%${filter.search.trim()}%`
+    conditions.push('(p.title ILIKE :search OR p.abstract ILIKE :search OR p.author_display ILIKE :search)')
+  }
+  if (filter.tiers.length > 0) {
+    bind.tiers = filter.tiers
+    conditions.push('p.citation_tier IN (:tiers)')
+  }
+  if (filter.yearFrom !== undefined) {
+    bind.yearFrom = filter.yearFrom
+    conditions.push('p.publication_year >= :yearFrom')
+  }
+  if (filter.yearTo !== undefined) {
+    bind.yearTo = filter.yearTo
+    conditions.push('p.publication_year <= :yearTo')
+  }
+  if (filter.rfcxAuthored) {
+    conditions.push('p.is_rfcx_authored = TRUE')
+  }
+  if (filter.techniques.length > 0) {
+    bind.techniques = filter.techniques
+    // Require the publication to have ALL requested techniques (AND semantics).
+    bind.techniqueCount = filter.techniques.length
+    conditions.push(`p.id IN (
+      SELECT publication_id FROM publication_technique
+      WHERE technique_code IN (:techniques)
+      GROUP BY publication_id
+      HAVING COUNT(DISTINCT technique_code) = :techniqueCount
+    )`)
+  }
+
+  return { clause: conditions.join(' AND '), bind }
+}
+
+export const countPublications = async (sequelize: Sequelize, filter: PublicationsFilter): Promise<number> => {
+  const { clause, bind } = buildWhere(filter)
+  const rows = await sequelize.query(
+    `SELECT COUNT(*)::integer AS total FROM publication p WHERE ${clause}`,
+    { type: QueryTypes.SELECT, replacements: bind }
+  ) as unknown as Array<{ total: number }>
+  return rows[0]?.total ?? 0
+}
+
+export const listPublications = async (sequelize: Sequelize, filter: PublicationsFilter): Promise<PublicationListItem[]> => {
+  const { clause, bind } = buildWhere(filter)
+
+  const orderBy = filter.sort === 'citations'
+    ? 'p.cited_by_count DESC NULLS LAST, p.publication_year DESC NULLS LAST'
+    : filter.sort === 'title'
+      ? 'lower(p.title) ASC'
+      : 'p.publication_year DESC NULLS LAST, p.cited_by_count DESC NULLS LAST'
+
+  const rows = await sequelize.query(
+    `SELECT
+        p.id,
+        p.title,
+        p.publication_year AS "year",
+        p.doi,
+        p.url,
+        p.venue,
+        p.publication_type AS "publicationType",
+        COALESCE(p.authors, '[]'::jsonb) AS authors,
+        p.author_display AS "authorDisplay",
+        p.abstract,
+        p.cited_by_count AS "citedByCount",
+        p.citation_tier AS "citationTier",
+        p.is_rfcx_authored AS "isRfcxAuthored",
+        p.rfcx_curated_uses AS "rfcxCuratedUses",
+        (p.pdf_s3_key IS NOT NULL) AS "hasPdf",
+        COALESCE(
+          (SELECT array_agg(pt.technique_code ORDER BY t.sort_order)
+           FROM publication_technique pt
+           JOIN arbimon_technique t ON t.code = pt.technique_code
+           WHERE pt.publication_id = p.id),
+          ARRAY[]::varchar[]
+        ) AS techniques
+     FROM publication p
+     WHERE ${clause}
+     ORDER BY ${orderBy}
+     LIMIT :limit OFFSET :offset`,
+    { type: QueryTypes.SELECT, replacements: { ...bind, limit: filter.limit, offset: filter.offset } }
+  ) as unknown as PublicationListItem[]
+
+  return rows.map(r => ({ ...r, authors: Array.isArray(r.authors) ? r.authors : [], techniques: r.techniques ?? [] }))
+}
+
+// Facet counts: number of matching publications per technique, applying every
+// filter EXCEPT the technique filter itself (so the user can see how many
+// papers each technique would add/intersect).
+export const getTechniqueFacets = async (sequelize: Sequelize, filter: PublicationsFilter): Promise<PublicationTechniqueCount[]> => {
+  const facetFilter: PublicationsFilter = { ...filter, techniques: [] }
+  const { clause, bind } = buildWhere(facetFilter)
+
+  const rows = await sequelize.query(
+    `SELECT t.code, t.display_name AS "displayName", t.abbreviation, COUNT(DISTINCT p.id)::integer AS count
+     FROM arbimon_technique t
+     LEFT JOIN publication_technique pt ON pt.technique_code = t.code
+     LEFT JOIN publication p ON p.id = pt.publication_id AND ${clause}
+     GROUP BY t.code, t.display_name, t.abbreviation, t.sort_order
+     ORDER BY t.sort_order`,
+    { type: QueryTypes.SELECT, replacements: bind }
+  ) as unknown as PublicationTechniqueCount[]
+
+  return rows
+}
+
+export const listTechniques = async (sequelize: Sequelize): Promise<PublicationTechnique[]> => {
+  return await sequelize.query(
+    `SELECT code, display_name AS "displayName", abbreviation, description, sort_order AS "sortOrder"
+     FROM arbimon_technique ORDER BY sort_order`,
+    { type: QueryTypes.SELECT }
+  ) as unknown as PublicationTechnique[]
+}

--- a/apps/api/src/publications/publications-handler.int.test.ts
+++ b/apps/api/src/publications/publications-handler.int.test.ts
@@ -1,0 +1,70 @@
+import { describe, expect, test, vi } from 'vitest'
+
+import { makeApp } from '@rfcx-bio/testing/handlers'
+
+import { GET } from '~/api-helpers/types'
+import { routesPublications } from './index'
+import { getPublications, getPublicationTechniques } from './publications-bll'
+
+const ROUTE = '/publications'
+const TECHNIQUES_ROUTE = '/publications/techniques'
+
+vi.mock('./publications-bll', () => {
+  return {
+    getPublications: vi.fn(async () => await Promise.resolve({
+      total: 1,
+      limit: 20,
+      offset: 0,
+      items: [{
+        id: 1,
+        title: 'Real-time bioacoustics monitoring',
+        year: 2013,
+        doi: '10.7717/peerj.103',
+        url: 'https://doi.org/10.7717/peerj.103',
+        venue: 'PeerJ',
+        publicationType: 'article',
+        authors: ['T. M. Aide'],
+        authorDisplay: 'T. M. Aide et al.',
+        abstract: 'An abstract.',
+        citedByCount: 473,
+        citationTier: 'A',
+        techniques: ['pattern_matching'],
+        isRfcxAuthored: true,
+        rfcxCuratedUses: 'Arbimon (PM)',
+        hasPdf: true
+      }],
+      techniqueFacets: [{ code: 'pattern_matching', displayName: 'Pattern Matching', abbreviation: 'PM', count: 1 }]
+    })),
+    getPublicationTechniques: vi.fn(async () => await Promise.resolve([
+      { code: 'pattern_matching', displayName: 'Pattern Matching', abbreviation: 'PM', description: null, sortOrder: 1 }
+    ]))
+  }
+})
+
+describe('GET /publications', () => {
+  test('route exists', async () => {
+    const app = await makeApp(routesPublications)
+    const routes = [...app.routes.keys()]
+    expect(routes).toContain(ROUTE)
+    expect(routes).toContain(TECHNIQUES_ROUTE)
+  })
+
+  test('returns 200 with paginated list + facets', async () => {
+    const app = await makeApp(routesPublications)
+    const response = await app.inject({ method: GET, url: '/publications?technique=pattern_matching&tier=A' })
+    expect(getPublications).toHaveBeenCalledOnce()
+    expect(response.statusCode).toBe(200)
+    const body = response.json()
+    expect(body.total).toBe(1)
+    expect(body.items[0].citationTier).toBe('A')
+    expect(body.techniqueFacets[0].code).toBe('pattern_matching')
+  })
+
+  test('techniques lookup returns 200', async () => {
+    const app = await makeApp(routesPublications)
+    const response = await app.inject({ method: GET, url: '/publications/techniques' })
+    expect(getPublicationTechniques).toHaveBeenCalledOnce()
+    expect(response.statusCode).toBe(200)
+    expect(response.json()[0].code).toBe('pattern_matching')
+  })
+})

--- a/apps/api/src/publications/publications-handler.ts
+++ b/apps/api/src/publications/publications-handler.ts
@@ -1,0 +1,54 @@
+import { type PublicationsQueryParams, type PublicationsResponse, type PublicationTechnique } from '@rfcx-bio/common/api-bio/publications/publications'
+
+import { type Handler } from '~/api-helpers/types'
+import { getPublications, getPublicationTechniques } from './publications-bll'
+import { type PublicationsFilter } from './publications-dao'
+
+const MAX_LIMIT = 100
+const DEFAULT_LIMIT = 20
+
+const toArray = (v: string | string[] | undefined): string[] => {
+  if (v === undefined) return []
+  return Array.isArray(v) ? v : [v]
+}
+
+const toIntOrUndefined = (v: unknown): number | undefined => {
+  if (v === undefined || v === null || v === '') return undefined
+  const n = Number(v)
+  return Number.isFinite(n) ? Math.trunc(n) : undefined
+}
+
+const ALLOWED_TIERS = new Set(['A', 'B', 'C'])
+const ALLOWED_SORT = new Set(['year', 'citations', 'title'])
+
+export const publicationsHandler: Handler<PublicationsResponse, unknown, PublicationsQueryParams> = async (req, res) => {
+  const q = req.query
+
+  const limitRaw = toIntOrUndefined(q.limit) ?? DEFAULT_LIMIT
+  const limit = Math.min(Math.max(limitRaw, 1), MAX_LIMIT)
+  const offset = Math.max(toIntOrUndefined(q.offset) ?? 0, 0)
+
+  const tiers = toArray(q.tier as string | string[] | undefined).filter(t => ALLOWED_TIERS.has(t))
+  const sort = (typeof q.sort === 'string' && ALLOWED_SORT.has(q.sort) ? q.sort : 'year')
+
+  const filter: PublicationsFilter = {
+    search: typeof q.search === 'string' ? q.search : undefined,
+    techniques: toArray(q.technique),
+    tiers,
+    yearFrom: toIntOrUndefined(q.yearFrom),
+    yearTo: toIntOrUndefined(q.yearTo),
+    rfcxAuthored: q.rfcxAuthored === true || (q.rfcxAuthored as unknown) === 'true',
+    limit,
+    offset,
+    sort
+  }
+
+  // cache for 1 hour at the edge (matches the legacy landing endpoint)
+  void res.header('Cache-control', 'public s-maxage=3600')
+  return await getPublications(filter)
+}
+
+export const publicationTechniquesHandler: Handler<PublicationTechnique[]> = async (_, res) => {
+  void res.header('Cache-control', 'public s-maxage=3600')
+  return await getPublicationTechniques()
+}

--- a/packages/common/src/api-bio/publications/publications.ts
+++ b/packages/common/src/api-bio/publications/publications.ts
@@ -1,0 +1,78 @@
+import { type AxiosInstance } from 'axios'
+
+// A single publication in the Arbimon citations index.
+export interface PublicationListItem {
+  id: number
+  title: string
+  year: number | null
+  doi: string | null
+  url: string | null
+  venue: string | null
+  publicationType: string | null
+  authors: string[]
+  authorDisplay: string | null
+  abstract: string | null
+  citedByCount: number | null
+  citationTier: 'A' | 'B' | 'C'
+  techniques: string[]
+  isRfcxAuthored: boolean
+  rfcxCuratedUses: string | null
+  hasPdf: boolean
+}
+
+export interface PublicationTechniqueCount {
+  code: string
+  displayName: string
+  abbreviation: string | null
+  count: number
+}
+
+export interface PublicationsResponse {
+  total: number
+  limit: number
+  offset: number
+  items: PublicationListItem[]
+  // Facet counts across the *filtered* set (excluding the technique filter itself)
+  techniqueFacets: PublicationTechniqueCount[]
+}
+
+export interface PublicationsQueryParams {
+  // Free-text search over title + abstract + authors
+  search?: string
+  // Filter by technique code (e.g. 'pattern_matching'); repeatable
+  technique?: string | string[]
+  // Filter by citation tier
+  tier?: 'A' | 'B' | 'C' | Array<'A' | 'B' | 'C'>
+  yearFrom?: number
+  yearTo?: number
+  // Only papers authored by the RFCx/Arbimon team
+  rfcxAuthored?: boolean
+  // Pagination
+  limit?: number
+  offset?: number
+  // Sort: 'year' (desc, default), 'citations' (desc), 'title' (asc)
+  sort?: 'year' | 'citations' | 'title'
+}
+
+export const publicationsRoute = '/publications'
+
+export const apiBioGetPublications = async (apiClient: AxiosInstance, params?: PublicationsQueryParams): Promise<PublicationsResponse> => {
+  const response = await apiClient.get(publicationsRoute, { params })
+  return response.data
+}
+
+// Technique taxonomy lookup endpoint
+export interface PublicationTechnique {
+  code: string
+  displayName: string
+  abbreviation: string | null
+  description: string | null
+  sortOrder: number
+}
+
+export const publicationTechniquesRoute = '/publications/techniques'
+
+export const apiBioGetPublicationTechniques = async (apiClient: AxiosInstance): Promise<PublicationTechnique[]> => {
+  const response = await apiClient.get(publicationTechniquesRoute)
+  return response.data
+}


### PR DESCRIPTION
## What
Replaces the placeholder **Google-Sheet** source for publications with the `publication` / `publication_technique` / `arbimon_technique` tables (insights DB, shipped in 260629-01/02), and adds a richer faceted browse API for the planned arbimon.org publications page. **No UI in this PR.**

## Endpoints
- **`GET /landing/publications`** (existing) — BLL rewritten to read the RFCx-curated subset (`in_rfcx_curated_list`) from the DB instead of the hardcoded Google Sheet. **Same response contract** (`Publication[]`) so the current frontend + its int-test are unchanged. `GOOGLE_SPREADSHEET_API_KEY` left as an optional env (now unused).
- **`GET /publications`** (new) — paginated, filterable list:
  - `search` over title + abstract + authors
  - `technique[]` (AND semantics), `tier[]`, `yearFrom`/`yearTo`, `rfcxAuthored`
  - `sort` = year | citations | title; `limit`/`offset`
  - returns items + **per-technique facet counts** over the filtered set
  - respects `is_visible`/`review_status` → Tier C `pending` stays hidden
- **`GET /publications/techniques`** (new) — the technique taxonomy lookup.

## Implementation
- Raw **parameterized** SQL via Sequelize (`QueryTypes.SELECT`, replacements); BLL uses `getSequelize()`. Mirrors the richness/species DAO pattern.
- New `common` contract `api-bio/publications` (types + client + route consts).
- Public (no-auth) routes, edge-cached 1h.

## Validation
- New int-tests for both routes (mocked BLL); existing landing-publications test still green.
- `tsc --noEmit -p tsconfig.build.json`: **0 errors** (api + common). eslint **clean**.

## Follow-up (separate)
OpenSearch `publications` index + indexer (sync-all/incremental) for full-text + technique-faceted search; arbimon.org UI.