### PR TITLE
feat(search): OpenSearch publications index + indexer + API integration

### DIFF
--- a/apps/api/src/publications/publications-bll.ts
+++ b/apps/api/src/publications/publications-bll.ts
@@ -1,24 +1,40 @@
 import { type PublicationsResponse, type PublicationTechnique } from '@rfcx-bio/common/api-bio/publications/publications'
 
 import { getSequelize } from '~/db'
+import { env } from '~/env'
 import { type PublicationsFilter, countPublications, getTechniqueFacets, listPublications, listTechniques } from './publications-dao'
+import { searchOpensearchPublications } from './publications-opensearch-dao'
 
 export const getPublications = async (filter: PublicationsFilter): Promise<PublicationsResponse> => {
   const sequelize = getSequelize()
 
+  // Facet counts always come from Postgres (cheap aggregate, always consistent).
+  const facetsPromise = getTechniqueFacets(sequelize, filter)
+
+  // Full-text relevance ranking via OpenSearch when enabled AND a search term is
+  // present; otherwise the Postgres DAO (which also covers the no-search case).
+  const useOpensearch = env.OPENSEARCH_ENABLED === 'true' && (filter.search?.trim() ?? '') !== ''
+
+  if (useOpensearch) {
+    try {
+      const [{ total, data }, techniqueFacets] = await Promise.all([
+        searchOpensearchPublications(filter),
+        facetsPromise
+      ])
+      return { total, limit: filter.limit, offset: filter.offset, items: data, techniqueFacets }
+    } catch (e) {
+      // Fail open to Postgres if OpenSearch is unavailable.
+      console.error('[publications] opensearch search failed, falling back to postgres', e)
+    }
+  }
+
   const [total, items, techniqueFacets] = await Promise.all([
     countPublications(sequelize, filter),
     listPublications(sequelize, filter),
-    getTechniqueFacets(sequelize, filter)
+    facetsPromise
   ])
 
-  return {
-    total,
-    limit: filter.limit,
-    offset: filter.offset,
-    items,
-    techniqueFacets
-  }
+  return { total, limit: filter.limit, offset: filter.offset, items, techniqueFacets }
 }
 
 export const getPublicationTechniques = async (): Promise<PublicationTechnique[]> => {

--- a/apps/api/src/publications/publications-opensearch-dao.ts
+++ b/apps/api/src/publications/publications-opensearch-dao.ts
@@ -1,0 +1,106 @@
+import { type Search } from '@opensearch-project/opensearch/api/requestParams'
+
+import { type PublicationListItem } from '@rfcx-bio/common/api-bio/publications/publications'
+
+import { getOpenSearchClient } from '~/opensearch'
+import { type PublicationsFilter } from './publications-dao'
+
+const PUBLICATIONS_INDEX = 'publications'
+
+interface RawHit {
+  _id: string
+  _source: {
+    title: string
+    abstract: string | null
+    authors: string[]
+    author_display: string | null
+    venue: string | null
+    publication_type: string | null
+    year: number | null
+    doi: string | null
+    url: string | null
+    cited_by_count: number | null
+    citation_tier: 'A' | 'B' | 'C'
+    techniques: string[]
+    rfcx_curated_uses: string | null
+    is_rfcx_authored: boolean
+    has_pdf: boolean
+  }
+}
+
+// Full-text search of the publications index. Applies the same structured
+// filters (technique/tier/year/rfcxAuthored) as the SQL DAO, but ranks by
+// relevance over title + abstract + authors.
+export const searchOpensearchPublications = async (filter: PublicationsFilter): Promise<{ total: number, data: PublicationListItem[] }> => {
+  const opensearch = getOpenSearchClient()
+
+  const filterClauses: Array<Record<string, unknown>> = []
+  if (filter.tiers.length > 0) filterClauses.push({ terms: { citation_tier: filter.tiers } })
+  if (filter.rfcxAuthored) filterClauses.push({ term: { is_rfcx_authored: true } })
+  if (filter.yearFrom !== undefined || filter.yearTo !== undefined) {
+    const range: Record<string, number> = {}
+    if (filter.yearFrom !== undefined) range.gte = filter.yearFrom
+    if (filter.yearTo !== undefined) range.lte = filter.yearTo
+    filterClauses.push({ range: { year: range } })
+  }
+  // AND semantics: require every requested technique
+  for (const tech of filter.techniques) {
+    filterClauses.push({ term: { techniques: tech } })
+  }
+
+  const sortBy: Array<Record<string, unknown> | string> = filter.sort === 'citations'
+    ? [{ cited_by_count: { order: 'desc' } }, '_score']
+    : filter.sort === 'title'
+      ? [{ author_display: { order: 'asc' } }, '_score']
+      : ['_score', { year: { order: 'desc' } }]
+
+  const params: Search<Record<string, unknown>> = {
+    index: PUBLICATIONS_INDEX,
+    from: filter.offset,
+    size: filter.limit,
+    body: {
+      track_total_hits: true,
+      query: {
+        bool: {
+          must: filter.search && filter.search.trim() !== ''
+            ? [{
+                multi_match: {
+                  query: filter.search.trim(),
+                  type: 'best_fields',
+                  fields: ['title^3', 'title.suggest^2', 'abstract', 'authors', 'rfcx_curated_uses']
+                }
+              }]
+            : [{ match_all: {} }],
+          filter: filterClauses
+        }
+      },
+      sort: sortBy
+    }
+  }
+
+  const response = await opensearch.search(params)
+  const body = response.body as { hits: { total: { value: number } | number, hits: RawHit[] } }
+  const totalRaw = body.hits.total
+  const total = typeof totalRaw === 'number' ? totalRaw : totalRaw.value
+
+  const data: PublicationListItem[] = body.hits.hits.map(h => ({
+    id: Number(h._id),
+    title: h._source.title,
+    year: h._source.year,
+    doi: h._source.doi,
+    url: h._source.url,
+    venue: h._source.venue,
+    publicationType: h._source.publication_type,
+    authors: Array.isArray(h._source.authors) ? h._source.authors : [],
+    authorDisplay: h._source.author_display,
+    abstract: h._source.abstract,
+    citedByCount: h._source.cited_by_count,
+    citationTier: h._source.citation_tier,
+    techniques: Array.isArray(h._source.techniques) ? h._source.techniques : [],
+    isRfcxAuthored: h._source.is_rfcx_authored,
+    rfcxCuratedUses: h._source.rfcx_curated_uses,
+    hasPdf: h._source.has_pdf
+  }))
+
+  return { total, data }
+}

--- a/apps/cli/src/search/publications/index.ts
+++ b/apps/cli/src/search/publications/index.ts
@@ -1,0 +1,84 @@
+import { type Dayjs } from 'dayjs'
+import { type Sequelize, QueryTypes } from 'sequelize'
+
+export const PUBLICATIONS_INDEX_NAME = 'publications'
+
+export interface PublicationDocument {
+  id: number
+  title: string
+  abstract: string | null
+  authors: string[]
+  author_display: string | null
+  venue: string | null
+  publication_type: string | null
+  year: number | null
+  doi: string | null
+  url: string | null
+  cited_by_count: number | null
+  citation_tier: string
+  techniques: string[]
+  rfcx_curated_uses: string | null
+  is_rfcx_authored: boolean
+  has_pdf: boolean
+}
+
+const BASE_SELECT = `
+  SELECT
+    p.id,
+    p.title,
+    p.abstract,
+    COALESCE(p.authors, '[]'::jsonb) AS authors,
+    p.author_display,
+    p.venue,
+    p.publication_type,
+    p.publication_year AS year,
+    p.doi,
+    p.url,
+    p.cited_by_count,
+    p.citation_tier,
+    COALESCE(
+      (SELECT array_agg(pt.technique_code ORDER BY t.sort_order)
+       FROM publication_technique pt
+       JOIN arbimon_technique t ON t.code = pt.technique_code
+       WHERE pt.publication_id = p.id),
+      ARRAY[]::varchar[]
+    ) AS techniques,
+    p.rfcx_curated_uses,
+    p.is_rfcx_authored,
+    (p.pdf_s3_key IS NOT NULL) AS has_pdf
+  FROM publication p
+`
+
+const normalize = (rows: PublicationDocument[]): PublicationDocument[] =>
+  rows.map(r => ({ ...r, authors: Array.isArray(r.authors) ? r.authors : [], techniques: r.techniques ?? [] }))
+
+// Visible + approved publications (eligible for the public index).
+export const getEligiblePublications = async (sequelize: Sequelize, updatedAfter?: Dayjs): Promise<PublicationDocument[]> => {
+  const conditions = ['p.is_visible = TRUE', "p.review_status = 'approved'"]
+  const bind: Record<string, unknown> = {}
+  if (updatedAfter) {
+    conditions.push('p.updated_at >= :updatedAfter')
+    bind.updatedAfter = updatedAfter.toISOString()
+  }
+  const rows = await sequelize.query(
+    `${BASE_SELECT} WHERE ${conditions.join(' AND ')} ORDER BY p.id`,
+    { type: QueryTypes.SELECT, replacements: bind }
+  ) as unknown as PublicationDocument[]
+  return normalize(rows)
+}
+
+// Publications that should NOT be in the index (hidden/pending), optionally only
+// those changed since the checkpoint — used to remove docs that became ineligible.
+export const getIneligiblePublications = async (sequelize: Sequelize, updatedAfter?: Dayjs): Promise<Array<{ id: number }>> => {
+  const conditions = ["(p.is_visible = FALSE OR p.review_status <> 'approved')"]
+  const bind: Record<string, unknown> = {}
+  if (updatedAfter) {
+    conditions.push('p.updated_at >= :updatedAfter')
+    bind.updatedAfter = updatedAfter.toISOString()
+  }
+  const rows = await sequelize.query(
+    `SELECT p.id FROM publication p WHERE ${conditions.join(' AND ')} ORDER BY p.id`,
+    { type: QueryTypes.SELECT, replacements: bind }
+  ) as unknown as Array<{ id: number }>
+  return rows
+}

--- a/apps/cli/src/search/publications/mappings.ts
+++ b/apps/cli/src/search/publications/mappings.ts
@@ -1,0 +1,70 @@
+// OpenSearch mapping for the `publications` index. Full-text over title +
+// abstract + authors, with keyword facets for technique/tier/year.
+const publicationsMappings = {
+  properties: {
+    title: {
+      type: 'text',
+      fields: {
+        suggest: { type: 'search_as_you_type' }
+      }
+    },
+    abstract: {
+      type: 'text',
+      analyzer: 'simple'
+    },
+    authors: {
+      type: 'text'
+    },
+    author_display: {
+      type: 'keyword',
+      ignore_above: 512
+    },
+    venue: {
+      type: 'text',
+      fields: {
+        keyword: { type: 'keyword', ignore_above: 256 }
+      }
+    },
+    publication_type: {
+      type: 'keyword',
+      ignore_above: 64
+    },
+    year: {
+      type: 'integer'
+    },
+    doi: {
+      type: 'keyword',
+      ignore_above: 256
+    },
+    url: {
+      type: 'keyword',
+      ignore_above: 1024
+    },
+    cited_by_count: {
+      type: 'integer'
+    },
+    citation_tier: {
+      type: 'keyword',
+      ignore_above: 1
+    },
+    techniques: {
+      type: 'keyword'
+    },
+    rfcx_curated_uses: {
+      type: 'text',
+      fields: {
+        keyword: { type: 'keyword', ignore_above: 256 }
+      }
+    },
+    is_rfcx_authored: {
+      type: 'boolean'
+    },
+    has_pdf: {
+      type: 'boolean'
+    }
+  }
+} as const
+
+export const getPublicationsMappings = (): typeof publicationsMappings => {
+  return publicationsMappings
+}

--- a/apps/cli/src/search/publications/sync.ts
+++ b/apps/cli/src/search/publications/sync.ts
@@ -1,0 +1,99 @@
+import { type Client } from '@opensearch-project/opensearch'
+import { type Dayjs } from 'dayjs'
+import { type Sequelize } from 'sequelize'
+
+import { masterSources, masterSyncDataTypes } from '@rfcx-bio/node-common/dao/master-data'
+import { ModelRepository } from '@rfcx-bio/node-common/dao/model-repository'
+import { dayjs } from '@rfcx-bio/utils/dayjs-initialized'
+
+import { SYNC_BATCH_LIMIT } from '../constants'
+import { deleteDocument, ensureRequiredIndexInitialized, refreshIndex } from '../opensearch/utilities'
+import { getCurrentDatabaseTime } from '../postgres'
+import { getEligiblePublications, getIneligiblePublications, PUBLICATIONS_INDEX_NAME } from './index'
+import { getPublicationsMappings } from './mappings'
+
+const indexBody = { mappings: getPublicationsMappings() }
+
+const savePublicationsSyncStatus = async (sequelize: Sequelize, syncUntilDate: Dayjs): Promise<void> => {
+  const { SyncStatus } = ModelRepository.getInstance(sequelize)
+  const where = {
+    syncSourceId: masterSources.NewArbimon.id,
+    syncDataTypeId: masterSyncDataTypes.OpensearchPublications.id
+  }
+  const existing = await SyncStatus.findOne({ where })
+  if (existing === null || existing === undefined) {
+    await SyncStatus.create({ ...where, syncUntilDate: syncUntilDate.toDate(), syncUntilId: '0', syncBatchLimit: SYNC_BATCH_LIMIT })
+  } else {
+    await SyncStatus.update({ syncUntilDate: syncUntilDate.toDate() }, { where })
+  }
+}
+
+const indexPublication = async (client: Client, doc: { id: number }): Promise<void> => {
+  const { id, ...body } = doc
+  await client.index({ index: PUBLICATIONS_INDEX_NAME, id: id.toString(), body })
+}
+
+export const syncAllPublications = async (client: Client, sequelize: Sequelize): Promise<void> => {
+  console.info('- [publications] ensuring the index is present')
+  await ensureRequiredIndexInitialized(client, PUBLICATIONS_INDEX_NAME, indexBody)
+
+  console.info('- [publications] querying current database time as checkpoint')
+  const currentDbTime = await getCurrentDatabaseTime(sequelize)
+
+  console.info('- [publications] removing ineligible (hidden/pending) publications')
+  const ineligible = await getIneligiblePublications(sequelize)
+  for (const p of ineligible) {
+    await deleteDocument(client, PUBLICATIONS_INDEX_NAME, p.id.toString())
+  }
+  console.info('- [publications] removed', ineligible.length, 'ineligible publications')
+
+  console.info('- [publications] indexing eligible publications')
+  const eligible = await getEligiblePublications(sequelize)
+  for (const doc of eligible) {
+    await indexPublication(client, doc)
+  }
+  console.info('- [publications] indexed', eligible.length, 'publications')
+
+  await savePublicationsSyncStatus(sequelize, currentDbTime)
+  await refreshIndex(client, PUBLICATIONS_INDEX_NAME)
+}
+
+export const syncAllPublicationsIncrementally = async (client: Client, sequelize: Sequelize): Promise<void> => {
+  const { SyncStatus } = ModelRepository.getInstance(sequelize)
+
+  console.info('- [publications] ensuring the index is present')
+  await ensureRequiredIndexInitialized(client, PUBLICATIONS_INDEX_NAME, indexBody)
+
+  const currentDbTime = await getCurrentDatabaseTime(sequelize)
+
+  const checkpoint = await SyncStatus.findOne({
+    where: {
+      syncSourceId: masterSources.NewArbimon.id,
+      syncDataTypeId: masterSyncDataTypes.OpensearchPublications.id
+    }
+  })
+
+  if (checkpoint === null || checkpoint === undefined) {
+    console.info('- [publications] no checkpoint found, performing full reindex')
+    await syncAllPublications(client, sequelize)
+    return
+  }
+
+  const since = dayjs(checkpoint.syncUntilDate)
+
+  console.info('- [publications] removing publications that became ineligible since checkpoint')
+  const ineligible = await getIneligiblePublications(sequelize, since)
+  for (const p of ineligible) {
+    await deleteDocument(client, PUBLICATIONS_INDEX_NAME, p.id.toString())
+  }
+
+  console.info('- [publications] indexing publications updated since checkpoint')
+  const updated = await getEligiblePublications(sequelize, since)
+  for (const doc of updated) {
+    await indexPublication(client, doc)
+  }
+  console.info('- [publications] indexed', updated.length, 'updated publications')
+
+  await savePublicationsSyncStatus(sequelize, currentDbTime)
+  await refreshIndex(client, PUBLICATIONS_INDEX_NAME)
+}

--- a/apps/cli/src/search/recreate-index/index.ts
+++ b/apps/cli/src/search/recreate-index/index.ts
@@ -6,6 +6,9 @@ import { PROJECTS_INDEX_NAME } from '../constants'
 import { getAnalysis } from '../opensearch/analysis'
 import { getMappings } from '../opensearch/mappings'
 import { createIndex, deleteIndex, getAvailableIndexes } from '../opensearch/utilities'
+import { PUBLICATIONS_INDEX_NAME } from '../publications/index'
+import { getPublicationsMappings } from '../publications/mappings'
+import { syncAllPublications } from '../publications/sync'
 
 export const recreateIndex = async (client: Client, index: string, body: object): Promise<void> => {
   console.info('- recreateIndex: getting available indexes from opensearch')
@@ -36,4 +39,11 @@ export const recreateIndexes = async (client: Client, sequelize: Sequelize): Pro
   console.info('- finished deleting the entry from sync_status')
   console.info('- starting the full reindex')
   await syncAllProjects(client, sequelize)
+
+  console.info('- recreating the publications index')
+  await recreateIndex(client, PUBLICATIONS_INDEX_NAME, { mappings: getPublicationsMappings() })
+  console.info('- deleting the publications entry from sync_status to force a reindex')
+  await sequelize.query('delete from sync_status where sync_source_id = 300 and sync_data_type_id = 810', { type: QueryTypes.DELETE })
+  console.info('- starting the full publications reindex')
+  await syncAllPublications(client, sequelize)
 }

--- a/apps/cli/src/search/sync-all.ts
+++ b/apps/cli/src/search/sync-all.ts
@@ -1,6 +1,7 @@
 import { getSequelize } from '@/db/connections'
 import { syncAllProjects } from './all'
 import { getOpenSearchClient } from './opensearch/utilities'
+import { syncAllPublications } from './publications/sync'
 
 const main = async (): Promise<void> => {
   console.info('Opensearch daily sync start')
@@ -10,6 +11,7 @@ const main = async (): Promise<void> => {
     const sequelize = getSequelize()
 
     await syncAllProjects(opensearchClient, sequelize)
+    await syncAllPublications(opensearchClient, sequelize)
   } catch (e) {
     console.error(e)
     process.exitCode = 1

--- a/apps/cli/src/search/sync-incremental.ts
+++ b/apps/cli/src/search/sync-incremental.ts
@@ -1,6 +1,7 @@
 import { getSequelize } from '@/db/connections'
 import { syncAllProjectsIncrementally } from './incremental'
 import { getOpenSearchClient } from './opensearch/utilities'
+import { syncAllPublicationsIncrementally } from './publications/sync'
 
 const main = async (): Promise<void> => {
   console.info('opensearch incremental reindex start')
@@ -10,6 +11,7 @@ const main = async (): Promise<void> => {
     const sequelize = getSequelize()
 
     await syncAllProjectsIncrementally(opensearchClient, sequelize)
+    await syncAllPublicationsIncrementally(opensearchClient, sequelize)
   } catch (e) {
     console.error(e)
     process.exitCode = 1

--- a/packages/node-common/src/dao/master-data/sync-data-type.ts
+++ b/packages/node-common/src/dao/master-data/sync-data-type.ts
@@ -10,7 +10,8 @@ export const masterSyncDataTypes = {
   Recording: { id: 500, name: 'Recording' },
   Detection: { id: 600, name: 'Detection' },
   RecordingDeleted: { id: 700, name: 'Recording Deleted' },
-  Opensearch: { id: 800, name: 'Opensearch' }
+  Opensearch: { id: 800, name: 'Opensearch' },
+  OpensearchPublications: { id: 810, name: 'Opensearch Publications' }
 } as const
 
 export type SyncTypesId = ValueOf<typeof masterSyncDataTypes>['id']


### PR DESCRIPTION
## What
Adds a **`publications` OpenSearch index** alongside `projects`, wired into the existing daily + incremental sync flows, and makes `GET /publications` use it for relevance-ranked full-text search when `OPENSEARCH_ENABLED`. **No UI.**

## CLI (indexer)
- `search/publications/mappings.ts` — mapping: `title` (+ `title.suggest` search-as-you-type), `abstract`, `authors` as text; `techniques`/`citation_tier`/`year`/flags as keyword/int/bool.
- `search/publications/index.ts` — eligible (`is_visible` + `approved`) / ineligible queries against the `publication` table (techniques as arrays).
- `search/publications/sync.ts` — `syncAllPublications` + `...Incrementally`, with a **dedicated `sync_status` checkpoint** (source NewArbimon, new data type `OpensearchPublications=810`) keyed on `publication.updated_at` — independent of the projects checkpoint.
- Wired into `sync-all.ts`, `sync-incremental.ts` (rides the existing cronjobs `biodiversity-cli-opensearch-sync-all` / `-incremental`) and `recreate-index`.
- `node-common`: + `masterSyncDataTypes.OpensearchPublications (810)`; auto-seeded by `updateMasterData` on migrate — **no migration needed**.

## API
- `publications-opensearch-dao.ts` — relevance search over the publications index; same structured filters (technique **AND** / tier / year / rfcxAuthored).
- `publications-bll.ts` — uses OpenSearch when enabled **and** a search term is present; **fails open to Postgres** on any OpenSearch error. Facet counts always from Postgres.

## Validation
- `tsc --noEmit -p tsconfig.build.json`: **0 errors** across node-common/common/cli/api. eslint **clean**.
- Existing search int-tests unchanged (require live pg + opensearch via CI service containers).

## Rollout
After merge → CD builds biodiversity-cli/api. The index is created + populated on the next **recreate-indexes** run or the daily **sync-all** cronjob; I'll trigger a one-off recreate after the image lands and verify, then confirm the API returns OpenSearch-ranked results.

## Follow-up
arbimon.org UI (browse-by-technique page + in-app widget).