### PR TITLE
Tier rollback: remove all user-tier limits + threshold-gated self-serve delete/backup

### DIFF
--- a/apps/api/src/_hooks/require-project-capability.ts
+++ b/apps/api/src/_hooks/require-project-capability.ts
@@ -1,0 +1,22 @@
+import { isSuperUser } from '@/_services/auth0/is-super-user'
+import { getProjectCapabilities } from '@/projects/project-capabilities-bll'
+import { type Middleware } from '~/api-helpers/types'
+import { BioForbiddenError, BioUnauthorizedError } from '~/errors'
+
+/**
+ * Self-serve project delete / backup gating (2026-07-12, operator D3):
+ * super users always pass; regular members pass when their role has the
+ * corresponding permission AND the project is small enough
+ * (PROJECT_DELETE_MAX_RECORDINGS / PROJECT_BACKUP_MAX_RECORDINGS).
+ */
+
+export const requireProjectDeleteAllowed: Middleware<{ projectId?: string }> = async (req): Promise<void> => {
+  if (req.userId === undefined) throw BioUnauthorizedError()
+  if (isSuperUser(req)) return
+
+  const projectId = Number(req.params?.projectId)
+  if (Number.isNaN(projectId)) throw BioForbiddenError()
+
+  const capabilities = await getProjectCapabilities(req.headers.authorization ?? '', projectId, req.projectRole, false)
+  if (!capabilities.canDelete) throw BioForbiddenError()
+}

--- a/apps/api/src/_services/api-legacy-arbimon/__mocks__/index.ts
+++ b/apps/api/src/_services/api-legacy-arbimon/__mocks__/index.ts
@@ -7,3 +7,6 @@ export const updateProjectLegacy = vi.fn(async (): Promise<{ success: boolean, e
   return await Promise.resolve({ success: true })
 })
 export const updateProjectSlugLegacy = vi.fn(async (): Promise<void> => {})
+export const getProjectTieringUsageLegacy = vi.fn(async (): Promise<{ recordingMinutesCount: number, collaboratorCount: number, guestCount: number, patternMatchingCount: number, jobCount: number }> => {
+  return await Promise.resolve({ recordingMinutesCount: 0, collaboratorCount: 0, guestCount: 0, patternMatchingCount: 0, jobCount: 0 })
+})

--- a/apps/api/src/_services/env/keys.ts
+++ b/apps/api/src/_services/env/keys.ts
@@ -47,5 +47,10 @@ export const envKeysOptional = [
   'OPENSEARCH_SSL_ENABLED',
   'SUPER_USER_EMAILS',
   'BACKUP_TIMEFRAME_LIMIT',
-  'KUBERNETES_NAMESPACE'
+  'KUBERNETES_NAMESPACE',
+  // Max recordings a project may contain for a non-super owner/admin to
+  // self-serve delete / backup it (operator-adjustable; defaults in
+  // projects/project-capabilities-bll.ts)
+  'PROJECT_DELETE_MAX_RECORDINGS',
+  'PROJECT_BACKUP_MAX_RECORDINGS'
 ] as const

--- a/apps/api/src/backup/backup-handler.int.test.ts
+++ b/apps/api/src/backup/backup-handler.int.test.ts
@@ -1,5 +1,5 @@
 import { Op } from 'sequelize'
-import { afterAll, beforeAll, describe, expect, test } from 'vitest'
+import { afterAll, beforeAll, describe, expect, test, vi } from 'vitest'
 
 import { backupsRoute } from '@rfcx-bio/common/api-bio/backup/backups'
 import { getIdByRole } from '@rfcx-bio/common/roles'
@@ -11,6 +11,10 @@ import { routesBackup } from '@/backup/index'
 import { GET, POST } from '~/api-helpers/types'
 import { env } from '~/env'
 
+// The self-serve capability check calls legacy for the recording count
+// (mock returns 0 recordings => small project).
+vi.mock('~/api-legacy-arbimon')
+
 const { LocationProject, LocationProjectUserRole, Backup } = modelRepositoryWithElevatedPermissions
 
 const ROUTE = backupsRoute
@@ -20,8 +24,9 @@ const adminId = 9003
 const projectId1 = 2791456
 const projectId2 = 2791457
 
-// Backups are now gated on the SUPER_USER_EMAILS allow-list. Each
-// authorized request must carry a userToken.email on that list.
+// Backups (2026-07-12, operator D3): super users always; project
+// admins/owners can self-serve backups for SMALL projects
+// (<= PROJECT_BACKUP_MAX_RECORDINGS recordings).
 const SUPER_EMAIL = 'arbimon-admin@rfcx.org'
 const superUserToken = { email: SUPER_EMAIL }
 const nonSuperUserToken = { email: 'someone-else@rfcx.org' }
@@ -180,8 +185,8 @@ describe(`POST ${backupsRoute}`, async () => {
         expect(response.statusCode).toBe(404)
     })
 
-    test('non-super user cannot request a backup', async () => {
-        // Arrange
+    test('non-super plain member (role user) cannot request a backup', async () => {
+        // Arrange — role 'user' lacks the backup-project permission
         const app = await makeApp(routesBackup, { userId, userToken: nonSuperUserToken })
         const backup = {
             entity: 'project',
@@ -196,7 +201,47 @@ describe(`POST ${backupsRoute}`, async () => {
         })
 
         // Assert
-        expect(response.statusCode).toBe(401)
+        expect(response.statusCode).toBe(403)
+    })
+
+    test('non-super owner CAN request a backup for a small project', async () => {
+        // Arrange — owner + mocked legacy usage of 0 recordings (small)
+        const app = await makeApp(routesBackup, { userId: ownerId, userToken: nonSuperUserToken })
+        const backup = {
+            entity: 'project',
+            entityId: projectId1
+        }
+
+        // Act
+        const response = await app.inject({
+            method: POST,
+            url: ROUTE,
+            payload: backup
+        })
+
+        // Assert
+        expect(response.statusCode).toBe(201)
+    })
+
+    test('non-super owner cannot request a backup for a LARGE project', async () => {
+        // Arrange — owner, but the project exceeds the backup threshold
+        const legacyApi = await import('~/api-legacy-arbimon')
+        vi.mocked(legacyApi.getProjectTieringUsageLegacy).mockResolvedValueOnce({ recordingMinutesCount: 1000000, collaboratorCount: 0, guestCount: 0, patternMatchingCount: 0, jobCount: 0 })
+        const app = await makeApp(routesBackup, { userId: ownerId, userToken: nonSuperUserToken })
+        const backup = {
+            entity: 'project',
+            entityId: projectId1
+        }
+
+        // Act
+        const response = await app.inject({
+            method: POST,
+            url: ROUTE,
+            payload: backup
+        })
+
+        // Assert
+        expect(response.statusCode).toBe(403)
     })
 
     test('view-only project cannot request a backup', async () => {
@@ -284,8 +329,8 @@ describe(`GET ${backupsRoute}`, async () => {
         expect(response.statusCode).toBe(404)
     })
 
-    test('non-super user cannot fetch backup requests', async () => {
-        // Arrange
+    test('non-super plain member (role user) cannot fetch backup requests', async () => {
+        // Arrange — role 'user' lacks the backup-project permission
         const app = await makeApp(routesBackup, { userId, userToken: nonSuperUserToken })
 
         // Act
@@ -296,6 +341,6 @@ describe(`GET ${backupsRoute}`, async () => {
         })
 
         // Assert
-        expect(response.statusCode).toBe(401)
+        expect(response.statusCode).toBe(403)
     })
 })

--- a/apps/api/src/backup/index.ts
+++ b/apps/api/src/backup/index.ts
@@ -1,24 +1,25 @@
 import { backupsRoute } from '@rfcx-bio/common/api-bio/backup/backups'
 
-import { requireSuperUser } from '@/_hooks/require-super'
 import { createBackupRequestHandler, getBackupRequestsHandler } from '@/backup/backup-handler'
 import { validationHandler } from '@/backup/validation/handler'
 import { type RouteRegistration, GET, POST } from '~/api-helpers/types'
 
-// Project backups are restricted to org-level super users
-// (SUPER_USER_EMAILS allow-list, e.g. arbimon-admin@rfcx.org). The
-// validationHandler still enforces entity shape + view-only guards.
+// Project backups (2026-07-12, operator D3): super users
+// (SUPER_USER_EMAILS) can always request backups; regular project
+// admins/owners can self-serve backups for SMALL projects
+// (<= PROJECT_BACKUP_MAX_RECORDINGS, default 100 recordings). Authz +
+// entity shape + view-only guards enforced inside validationHandler.
 export const routesBackup: RouteRegistration[] = [
   {
     method: GET,
     url: backupsRoute,
-    preHandler: [requireSuperUser, validationHandler],
+    preHandler: [validationHandler],
     handler: getBackupRequestsHandler
   },
   {
     method: POST,
     url: backupsRoute,
-    preHandler: [requireSuperUser, validationHandler],
+    preHandler: [validationHandler],
     handler: createBackupRequestHandler
   }
 ]

--- a/apps/api/src/backup/validation/handler.ts
+++ b/apps/api/src/backup/validation/handler.ts
@@ -1,7 +1,12 @@
+import { type FastifyRequest } from 'fastify'
+
+import { isSuperUser } from '@/_services/auth0/is-super-user'
 import { ALLOWED_BACKUP_TYPES, BackupEntityGetters } from '@/backup/types'
+import { getUserRoleForProject } from '@/projects/dao/project-member-dao'
+import { getProjectCapabilities } from '@/projects/project-capabilities-bll'
 import { assertProjectExportAllowed } from '@/projects/project-entitlement-bll'
 import type { Middleware } from '~/api-helpers/types'
-import { BioInvalidPathParamError, BioMissingPathParamError, BioPublicError, BioUnauthorizedError } from '~/errors'
+import { BioForbiddenError, BioInvalidPathParamError, BioMissingPathParamError, BioPublicError, BioUnauthorizedError } from '~/errors'
 
 interface EntityData {
     entity?: string
@@ -22,11 +27,11 @@ export const validationHandler: Middleware<void> = async (req): Promise<void> =>
     // Validate entity data
     if (method !== undefined) {
         const entityData = payload[String(method)] ?? {}
-        await validateRequest(entityData)
+        await validateRequest(entityData, userId, req)
     }
 }
 
-const validateRequest = async (data: EntityData): Promise<void> => {
+const validateRequest = async (data: EntityData, userId: number, req: FastifyRequest): Promise<void> => {
     const { entity: entityType, entityId } = data
 
     if (entityType === undefined) {
@@ -49,10 +54,19 @@ const validateRequest = async (data: EntityData): Promise<void> => {
         throw new BioPublicError(`${String(entityType)} with id ${Number(entityId)} not found`, 404)
     }
 
-    // Authorization is enforced upstream by the requireSuperUser preHandler
-    // (SUPER_USER_EMAILS allow-list). Here we only keep the view-only guard
-    // so a locked project still cannot have backups requested.
     if (entityType === 'project') {
+        // Authorization (2026-07-12, operator D3): super users always; project
+        // admins/owners may self-serve backups for SMALL projects
+        // (<= PROJECT_BACKUP_MAX_RECORDINGS, default 100 recordings).
+        if (!isSuperUser(req)) {
+            const role = await getUserRoleForProject(userId, Number(entityId))
+            const capabilities = await getProjectCapabilities(req.headers.authorization ?? '', Number(entityId), role, false)
+            if (!capabilities.canBackup) {
+                throw BioForbiddenError()
+            }
+        }
+
+        // View-only guard: a locked project still cannot have backups requested.
         await assertProjectExportAllowed(entityId)
     }
 }

--- a/apps/api/src/projects/index.ts
+++ b/apps/api/src/projects/index.ts
@@ -1,3 +1,4 @@
+import { projectCapabilitiesRoute } from '@rfcx-bio/common/api-bio/project/project-capabilities'
 import { projectCreateRoute } from '@rfcx-bio/common/api-bio/project/project-create'
 import { projectDeleteRoute } from '@rfcx-bio/common/api-bio/project/project-delete'
 import { projectEntitlementSummaryRoute } from '@rfcx-bio/common/api-bio/project/project-entitlement-summary'
@@ -14,8 +15,9 @@ import { myProjectsRoute, projectBySlugRoute, projectsDeprecatedRoute, projectsG
 import { logBody } from '@/_hooks/log-body'
 import { requireAuthorized } from '@/_hooks/require-authenticated'
 import { requireProjectPermission } from '@/_hooks/require-permission'
-import { requireSuperUser } from '@/_hooks/require-super'
+import { requireProjectDeleteAllowed } from '@/_hooks/require-project-capability'
 import { type RouteRegistration, DELETE, GET, PATCH, POST } from '../_services/api-helpers/types'
+import { projectCapabilitiesHandler } from './project-capabilities-handler'
 import { projectCreateHandler } from './project-create-handler'
 import { projectDeleteHandler } from './project-delete-handler'
 import { projectEntitlementSummaryHandler } from './project-entitlement-summary-handler'
@@ -59,6 +61,12 @@ export const routesProject: RouteRegistration[] = [
     url: projectUploadLimitSummaryRoute,
     preHandler: [requireAuthorized],
     handler: projectUploadLimitSummaryHandler
+  },
+  {
+    method: GET,
+    url: projectCapabilitiesRoute,
+    preHandler: [requireAuthorized],
+    handler: projectCapabilitiesHandler
   },
   {
     method: GET,
@@ -139,9 +147,11 @@ export const routesProject: RouteRegistration[] = [
   {
     method: DELETE,
     url: projectDeleteRoute,
-    // Project deletion is restricted to org-level super users
-    // (SUPER_USER_EMAILS allow-list, e.g. arbimon-admin@rfcx.org).
-    preHandler: [requireSuperUser],
+    // Project deletion (2026-07-12, operator D3): super users always; project
+    // owners may self-serve delete SMALL projects (<= PROJECT_DELETE_MAX_RECORDINGS,
+    // default 60 recordings). Authz enforced inside the handler
+    // (requireProjectDeleteAllowed) because it needs the live recording count.
+    preHandler: [requireProjectDeleteAllowed],
     handler: projectDeleteHandler
   }
 ]

--- a/apps/api/src/projects/project-capabilities-bll.ts
+++ b/apps/api/src/projects/project-capabilities-bll.ts
@@ -1,0 +1,90 @@
+import { hasPermission } from '@rfcx-bio/common/roles'
+import { type ProjectRole } from '@rfcx-bio/common/roles'
+
+import { getProjectTieringUsageLegacy } from '~/api-legacy-arbimon'
+import { env } from '~/env'
+import { getProjectById } from './dao/projects-dao'
+
+/**
+ * Self-serve project delete / backup thresholds (2026-07-12, operator D3).
+ *
+ * Super users (SUPER_USER_EMAILS) can always delete/backup any project. In
+ * addition, regular project owners/admins can self-serve these operations on
+ * SMALL projects, where "small" is measured in recordings:
+ *   - delete: project has <= PROJECT_DELETE_MAX_RECORDINGS (default 60)
+ *   - backup: project has <= PROJECT_BACKUP_MAX_RECORDINGS (default 100)
+ *
+ * The thresholds are env-var-backed so the operator can adjust them without a
+ * code change (rfcx-local: configmap biodiversity-api-prod-overrides).
+ *
+ * The recordings count comes from legacy's tiering-usage endpoint
+ * (`recordingMinutesCount` is historically misnamed — it is a COUNT of
+ * recordings, which is exactly what we want here). If legacy is unreachable
+ * the count is unknown and we FAIL CLOSED for non-super users (destructive /
+ * expensive operations should not open up on a dependency outage).
+ */
+
+export const DEFAULT_PROJECT_DELETE_MAX_RECORDINGS = 60
+export const DEFAULT_PROJECT_BACKUP_MAX_RECORDINGS = 100
+
+const parseThreshold = (raw: string | undefined, fallback: number): number => {
+  if (raw === undefined || raw === '') return fallback
+  const value = Number(raw)
+  return Number.isFinite(value) && value >= 0 ? value : fallback
+}
+
+export const getProjectDeleteMaxRecordings = (): number =>
+  parseThreshold(env.PROJECT_DELETE_MAX_RECORDINGS, DEFAULT_PROJECT_DELETE_MAX_RECORDINGS)
+
+export const getProjectBackupMaxRecordings = (): number =>
+  parseThreshold(env.PROJECT_BACKUP_MAX_RECORDINGS, DEFAULT_PROJECT_BACKUP_MAX_RECORDINGS)
+
+export const getProjectRecordingCount = async (token: string, projectId: number): Promise<number | undefined> => {
+  const project = await getProjectById(projectId)
+  if (project === undefined) return undefined
+  try {
+    const usage = await getProjectTieringUsageLegacy(token, project.slug)
+    const count = Number(usage?.recordingMinutesCount)
+    return Number.isFinite(count) ? count : undefined
+  } catch (e) {
+    // Unknown count => fail closed for non-super callers.
+    return undefined
+  }
+}
+
+export interface ProjectCapabilities {
+  canDelete: boolean
+  canBackup: boolean
+  recordingCount: number | null
+  deleteMaxRecordings: number
+  backupMaxRecordings: number
+}
+
+export const getProjectCapabilities = async (
+  token: string,
+  projectId: number,
+  role: ProjectRole,
+  isSuper: boolean
+): Promise<ProjectCapabilities> => {
+  const deleteMax = getProjectDeleteMaxRecordings()
+  const backupMax = getProjectBackupMaxRecordings()
+
+  if (isSuper) {
+    return { canDelete: true, canBackup: true, recordingCount: null, deleteMaxRecordings: deleteMax, backupMaxRecordings: backupMax }
+  }
+
+  const canDeleteByRole = hasPermission(role, 'delete-project')
+  const canBackupByRole = hasPermission(role, 'backup-project')
+  if (!canDeleteByRole && !canBackupByRole) {
+    return { canDelete: false, canBackup: false, recordingCount: null, deleteMaxRecordings: deleteMax, backupMaxRecordings: backupMax }
+  }
+
+  const count = await getProjectRecordingCount(token, projectId)
+  return {
+    canDelete: canDeleteByRole && count !== undefined && count <= deleteMax,
+    canBackup: canBackupByRole && count !== undefined && count <= backupMax,
+    recordingCount: count ?? null,
+    deleteMaxRecordings: deleteMax,
+    backupMaxRecordings: backupMax
+  }
+}

--- a/apps/api/src/projects/project-capabilities-handler.ts
+++ b/apps/api/src/projects/project-capabilities-handler.ts
@@ -1,0 +1,24 @@
+import { type ProjectCapabilitiesResponse } from '@rfcx-bio/common/api-bio/project/project-capabilities'
+
+import { isSuperUser } from '@/_services/auth0/is-super-user'
+import { type Handler } from '~/api-helpers/types'
+import { BioInvalidPathParamError } from '~/errors'
+import { assertPathParamsExist } from '~/validation'
+import { getProjectCapabilities } from './project-capabilities-bll'
+
+export const projectCapabilitiesHandler: Handler<ProjectCapabilitiesResponse, { projectId: string }> = async (request) => {
+  const { projectId } = request.params
+  assertPathParamsExist({ projectId })
+
+  const projectIdInteger = Number(projectId)
+  if (Number.isNaN(projectIdInteger)) {
+    throw BioInvalidPathParamError({ projectId })
+  }
+
+  return await getProjectCapabilities(
+    request.headers.authorization ?? '',
+    projectIdInteger,
+    request.projectRole,
+    isSuperUser(request)
+  )
+}

--- a/apps/api/src/projects/project-delete-handler.int.test.ts
+++ b/apps/api/src/projects/project-delete-handler.int.test.ts
@@ -52,8 +52,9 @@ test(`DELETE ${projectDeleteRoute} deletes local project`, async () => {
   expect(project?.deletedAt).toBeTruthy()
 })
 
-test(`DELETE ${projectDeleteRoute} is forbidden for a non-super owner`, async () => {
-  // Arrange — owner of the project but NOT on the SUPER_USER_EMAILS list
+test(`DELETE ${projectDeleteRoute} is allowed for a non-super owner of a SMALL project`, async () => {
+  // 2026-07-12 (operator D3): owners can self-serve delete when the project
+  // has <= PROJECT_DELETE_MAX_RECORDINGS recordings (mocked legacy usage = 0).
   const app = await makeApp(routesProject, { userId, userToken: { idAuth0: 'test', email: 'not-super@rfcx.org' }, projectRole: 'owner' })
   const locationProjectId = await LocationProject.findOne({ where: { slug: { [Op.like]: 'snail%' } } }).then(p => p?.id ?? 0)
   const url = projectDeleteRoute.replace(':projectId', locationProjectId.toString())
@@ -62,6 +63,35 @@ test(`DELETE ${projectDeleteRoute} is forbidden for a non-super owner`, async ()
   const response = await app.inject({ method: DELETE, url, headers: { Authorization: fakeToken } })
 
   // Assert
-  expect(response.statusCode).toBe(401)
+  expect(response.statusCode).toBe(204)
+  expect(coreApi.deleteProject).toBeCalledTimes(1)
+})
+
+test(`DELETE ${projectDeleteRoute} is forbidden for a non-super owner of a LARGE project`, async () => {
+  // Arrange — owner, not super, and the project exceeds the delete threshold
+  const legacyApi = await import('~/api-legacy-arbimon')
+  vi.mocked(legacyApi.getProjectTieringUsageLegacy).mockResolvedValueOnce({ recordingMinutesCount: 1000000, collaboratorCount: 0, guestCount: 0, patternMatchingCount: 0, jobCount: 0 })
+  const app = await makeApp(routesProject, { userId, userToken: { idAuth0: 'test', email: 'not-super@rfcx.org' }, projectRole: 'owner' })
+  const locationProjectId = await LocationProject.findOne({ where: { slug: { [Op.like]: 'snail%' } } }).then(p => p?.id ?? 0)
+  const url = projectDeleteRoute.replace(':projectId', locationProjectId.toString())
+
+  // Act
+  const response = await app.inject({ method: DELETE, url, headers: { Authorization: fakeToken } })
+
+  // Assert
+  expect(response.statusCode).toBe(403)
+  expect(coreApi.deleteProject).not.toBeCalled()
+})
+
+test(`DELETE ${projectDeleteRoute} is forbidden for a non-super NON-owner even on a small project`, async () => {
+  const app = await makeApp(routesProject, { userId, userToken: { idAuth0: 'test', email: 'not-super@rfcx.org' }, projectRole: 'admin' })
+  const locationProjectId = await LocationProject.findOne({ where: { slug: { [Op.like]: 'snail%' } } }).then(p => p?.id ?? 0)
+  const url = projectDeleteRoute.replace(':projectId', locationProjectId.toString())
+
+  // Act
+  const response = await app.inject({ method: DELETE, url, headers: { Authorization: fakeToken } })
+
+  // Assert
+  expect(response.statusCode).toBe(403)
   expect(coreApi.deleteProject).not.toBeCalled()
 })

--- a/apps/api/src/tiering/tier-limit-bll.ts
+++ b/apps/api/src/tiering/tier-limit-bll.ts
@@ -35,17 +35,21 @@ interface AccountTierProjectLimitRow {
 const PROJECT_TYPE_LIMIT_TABLE = 'project_type_limit'
 const ACCOUNT_TIER_PROJECT_LIMIT_TABLE = 'account_tier_project_limit'
 
+// Tier rollback (2026-07-12): ALL limits are unlimited (NULL). The tier
+// mechanism is retained dormant; these defaults match the live
+// project_type_limit rows so a fresh seed cannot silently re-tighten limits.
+// See rfcx-local runbooks/AUDIT-arbimon-tier-limitations-rollback-plan-2026-07-12.md.
 const DEFAULT_PROJECT_LIMITS: Record<ProjectType, ProjectTypeLimit> = {
   free: {
-    recordingMinutesCount: 526000,
-    collaboratorCount: 3,
+    recordingMinutesCount: null,
+    collaboratorCount: null,
     guestCount: null,
     jobCount: null,
-    jobRecordingCount: 12000
+    jobRecordingCount: null
   },
   premium: {
     recordingMinutesCount: null,
-    collaboratorCount: 20,
+    collaboratorCount: null,
     guestCount: null,
     jobCount: null,
     jobRecordingCount: null
@@ -62,11 +66,11 @@ const DEFAULT_PROJECT_LIMITS: Record<ProjectType, ProjectTypeLimit> = {
 }
 
 const DEFAULT_ACCOUNT_TIER_PROJECT_LIMITS: Record<AccountTier, AccountTierProjectLimitMap> = {
-  // No project-COUNT cap enforced under the reframe (NULL = unlimited); the
-  // matrix mechanism is retained so an operator can impose counts later.
-  // free->premium stays 0 (a free user cannot self-own a premium project).
-  free: { free: null, premium: 0, unlimited: 0 },
-  pro: { free: null, premium: null, unlimited: 0 }
+  // Tier rollback (2026-07-12): no project-COUNT caps at all (NULL = unlimited,
+  // including free->premium per operator D2). The matrix mechanism is retained
+  // so an operator can impose counts later.
+  free: { free: null, premium: null, unlimited: null },
+  pro: { free: null, premium: null, unlimited: null }
 }
 
 const isMissingTableError = (error: unknown): boolean => {

--- a/apps/cli/src/db/migrations/260712-01-rollback-tier-limits.ts
+++ b/apps/cli/src/db/migrations/260712-01-rollback-tier-limits.ts
@@ -1,0 +1,92 @@
+import { type QueryInterface } from 'sequelize'
+import { type MigrationFn } from 'umzug'
+
+/**
+ * Tier rollback (2026-07-12, operator-directed): remove ALL user-tier /
+ * pricing-based limitations for normal usage of Arbimon.
+ *
+ * Runbook: rfcx-local `runbooks/AUDIT-arbimon-tier-limitations-rollback-plan-2026-07-12.md`
+ * (OPEN-ITEMS #51, operator decisions D1..D6 answered 2026-07-12).
+ *
+ * The tier MECHANISM stays in place (tables, columns, guards, super endpoints)
+ * but every limit becomes NULL (= unlimited) and every view-only lock is
+ * cleared. All server-side guards (bio-api assert*, legacy
+ * assertJobRecordingLimit, ingest-service upload quota) no-op on NULL limits,
+ * so this single migration restores pre-tiering behavior server-wide.
+ *
+ * 1. project_type_limit: all limit columns -> NULL for every project type.
+ *    (Pre-change live values 2026-07-12: free = 526000 rec-"minutes" / 3
+ *    collaborators / 300000 recs-per-job; premium = 20 collaborators; rest
+ *    already NULL. NOTE: the free job_recording_limit had already been raised
+ *    12000 -> 300000 by a direct-SQL change on 2026-07-02.)
+ * 2. account_tier_project_limit: all active_project_limit -> NULL (including
+ *    free->premium which was 0; operator D2).
+ * 3. location_project.is_locked: FALSE everywhere (operator D5 confirmed the
+ *    two projects locked 2026-07-08 should unlock too). Pre-change: 255 rows
+ *    (214 live free, 23 deleted free, 18 deleted premium).
+ *
+ * Idempotent: re-running is a no-op. Down restores the captured 2026-07-12
+ * limit values but does NOT re-lock projects (lock state was a legacy-model
+ * artifact; the authoritative pre-change lock list lives in the runbook).
+ */
+
+export const up: MigrationFn<QueryInterface> = async ({ context }) => {
+  await context.sequelize.query(`
+    UPDATE project_type_limit
+    SET recording_minutes_limit = NULL,
+        collaborator_limit = NULL,
+        guest_limit = NULL,
+        analyze_job_limit = NULL,
+        job_recording_limit = NULL,
+        updated_at = CURRENT_TIMESTAMP
+    WHERE recording_minutes_limit IS NOT NULL
+       OR collaborator_limit IS NOT NULL
+       OR guest_limit IS NOT NULL
+       OR analyze_job_limit IS NOT NULL
+       OR job_recording_limit IS NOT NULL;
+  `)
+
+  await context.sequelize.query(`
+    UPDATE account_tier_project_limit
+    SET active_project_limit = NULL,
+        updated_at = CURRENT_TIMESTAMP
+    WHERE active_project_limit IS NOT NULL;
+  `)
+
+  await context.sequelize.query(`
+    UPDATE location_project
+    SET is_locked = FALSE, updated_at = CURRENT_TIMESTAMP
+    WHERE is_locked = TRUE;
+  `)
+}
+
+export const down: MigrationFn<QueryInterface> = async ({ context }) => {
+  // Restore the last live limit values (captured 2026-07-12 pre-migration).
+  // Does NOT re-lock any project.
+  await context.sequelize.query(`
+    UPDATE project_type_limit
+    SET recording_minutes_limit = 526000,
+        collaborator_limit = 3,
+        job_recording_limit = 300000,
+        updated_at = CURRENT_TIMESTAMP
+    WHERE project_type = 'free';
+  `)
+  await context.sequelize.query(`
+    UPDATE project_type_limit
+    SET collaborator_limit = 20,
+        updated_at = CURRENT_TIMESTAMP
+    WHERE project_type = 'premium';
+  `)
+  await context.sequelize.query(`
+    UPDATE account_tier_project_limit
+    SET active_project_limit = 0,
+        updated_at = CURRENT_TIMESTAMP
+    WHERE account_tier = 'free' AND project_type IN ('premium', 'unlimited');
+  `)
+  await context.sequelize.query(`
+    UPDATE account_tier_project_limit
+    SET active_project_limit = 0,
+        updated_at = CURRENT_TIMESTAMP
+    WHERE account_tier = 'pro' AND project_type = 'unlimited';
+  `)
+}

--- a/apps/website/src/projects/_composables/use-project-capabilities.ts
+++ b/apps/website/src/projects/_composables/use-project-capabilities.ts
@@ -1,0 +1,13 @@
+import { type UseQueryReturnType, useQuery } from '@tanstack/vue-query'
+import { type AxiosInstance } from 'axios'
+import { type ComputedRef, computed } from 'vue'
+
+import { type ProjectCapabilitiesResponse, apiBioGetProjectCapabilities } from '@rfcx-bio/common/api-bio/project/project-capabilities'
+
+export const useGetProjectCapabilities = (apiClient: AxiosInstance, projectId: ComputedRef<number | undefined>): UseQueryReturnType<ProjectCapabilitiesResponse | undefined, unknown> => {
+  return useQuery({
+    queryKey: computed(() => ['fetch-project-capabilities', projectId.value]),
+    queryFn: async () => await apiBioGetProjectCapabilities(apiClient, projectId.value ?? -1),
+    enabled: computed(() => projectId.value !== undefined)
+  })
+}

--- a/apps/website/src/projects/components/create-analysis.vue
+++ b/apps/website/src/projects/components/create-analysis.vue
@@ -76,22 +76,12 @@ const analyses = ref([
   { value: 'rfm', title: 'Random Forest Model', description: 'A machine learning model, comprising multiple decision trees and trained with presence and absence data, designed to predict species presence in soundscape recordings. It serves as an efficient and accurate means of assessing species presence in diverse acoustic environments.', url: `${BASE_URL}/project/${selectedProject.value?.slug}/analysis/random-forest-models/models?newJob`, link: 'https://help.arbimon.org/category/199-analyze-recordings-with-random-forest-models-rfm', label: 'Learn more about RFM', isSelected: false }
 ])
 
-const isPMLimitReached = computed(() => {
-  const projectType = store.project?.projectType ?? 'free'
-  const currentPMJobs = store.project?.usage?.patternMatchingCount ?? 0
-
-  if (projectType === 'unlimited') return false
-
-  if (projectType === 'free') {
-    return currentPMJobs >= 50
-  }
-
-  if (projectType === 'premium') {
-    return currentPMJobs >= 200
-  }
-
-  return false
-})
+// Tier rollback (2026-07-12): analysis-job count caps removed. This computed
+// previously hardcoded the RETIRED 2026-05-19 caps (free>=50 / premium>=200
+// historical PM jobs) client-side, silently disabling the PM card for
+// long-running projects even after the caps were removed from the DB on
+// 2026-06-29. Kept as an always-false hook in case a cap ever returns.
+const isPMLimitReached = computed(() => false)
 
 const onSelectAnalysis = (url: string, value: string) => {
   if (isProjectViewOnly.value) return

--- a/apps/website/src/projects/components/form/project-delete.vue
+++ b/apps/website/src/projects/components/form/project-delete.vue
@@ -1,0 +1,147 @@
+<template>
+  <div class="flex flex-col gap-y-6">
+    <h4>
+      Danger Zone
+    </h4>
+    <div>
+      <div class="flex flex-row">
+        <span class="font-medium text-secondary">Delete project</span>
+        <icon-i-info
+          tooltip-id="project-delete"
+          :tooltip-text="'Delete this project permanently.'"
+        />
+      </div>
+      <div class="flex flex-row items-center mt-4">
+        <button
+          data-modal-target="project-delete-modal"
+          data-modal-toggle="project-delete-modal"
+          type="button"
+          class="btn btn-danger flex flex-row py-2"
+          @click="openModalToDeleteProject"
+        >
+          Delete project
+          <icon-custom-ic-loading
+            v-if="isDeleting"
+            class="animate-spin ml-2"
+          />
+          <icon-fa-trash
+            v-else
+            class="ml-2 cursor-pointer"
+          />
+        </button>
+        <div
+          id="project-delete-modal"
+          data-modal-backdrop="static"
+          tabindex="-1"
+          aria-hidden="true"
+          class="hidden overflow-y-auto overflow-x-hidden fixed top-0 right-0 left-0 z-50 justify-center items-center w-full md:inset-0 h-[calc(100%-1rem)] max-h-full"
+        >
+          <div class="relative w-full max-w-115 max-h-full">
+            <div class="relative p-6 bg-white rounded-lg shadow dark:bg-moss">
+              <div class="flex flex-col">
+                <div class="flex items-start justify-between">
+                  <div class="rounded-full bg-util-gray-01 p-3">
+                    <icon-fa-trash
+                      class="text-ibis"
+                    />
+                  </div>
+                  <button
+                    type="button"
+                    data-modal-toggle="project-delete-modal"
+                    title="Cancel"
+                    @click="closeModal"
+                  >
+                    <icon-custom-fi-close-thin class="h-6 w-6 cursor-pointer text-insight" />
+                  </button>
+                </div>
+                <div class="mt-6 w-full text-cloud">
+                  <h2>Delete project</h2>
+                  <div v-if="!isDeleting">
+                    <p class="mt-2">
+                      Are you sure you want to delete this project?
+                    </p>
+                    <p>This action cannot be undone</p>
+                  </div>
+                </div>
+                <div v-if="isDeleting">
+                  <icon-custom-ic-loading class="my-6 mx-auto animate-spin" />
+                </div>
+                <div
+                  v-if="isError"
+                  class="bg-danger-light mt-6 flex flex-row items-center p-2 border-l-3 rounded-lg border-l-ibis"
+                >
+                  <p class="ml-2 text-util-gray-04 text-sm">
+                    <span
+                      class="text-sm font-medium"
+                      role="alert"
+                    >
+                      A Server Error Occurred.
+                    </span>
+                    We encountered some issues while deleting your project. Could you please try again?
+                  </p>
+                </div>
+                <div class="flex flex-row justify-center items-center mt-8 gap-x-4">
+                  <button
+                    data-modal-hide="species-highlighted-modal"
+                    type="button"
+                    class="btn btn-secondary flex flex-row justify-center px-6 py-3 w-49"
+                    @click="closeModal"
+                  >
+                    <span>Cancel</span>
+                  </button>
+                  <button
+                    data-modal-target="project-delete-modal"
+                    data-modal-toggle="project-delete-modal"
+                    type="button"
+                    class="btn bg-ibis flex flex-row text-insight justify-center px-6 py-3 w-49"
+                    @click="accessToDelete"
+                  >
+                    <span>Delete project</span>
+                  </button>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { Modal } from 'flowbite'
+import { type Ref, onMounted, ref, watch } from 'vue'
+
+import IconIInfo from '../icon-i-info.vue'
+
+const props = defineProps<{isDeleting?: boolean, isError?: boolean, isSuccess?: boolean}>()
+const emit = defineEmits<{(e: 'emitProjectDelete'): void}>()
+
+const modal = ref() as Ref<Modal>
+
+watch(() => props.isSuccess, (val) => {
+  if (val === true) closeModal()
+})
+
+onMounted(() => {
+  modal.value = new Modal(document.getElementById('project-delete-modal'), {
+    placement: 'top-center',
+    backdrop: 'dynamic',
+    backdropClasses: 'bg-pitch bg-opacity-50 dark:bg-opacity-80 fixed inset-0 z-40',
+    closable: true
+  })
+})
+
+const openModalToDeleteProject = (): void => {
+  modal.value.show()
+}
+
+const accessToDelete = (): void => {
+  emit('emitProjectDelete')
+}
+
+const closeModal = (): void => {
+  modal.value.hide()
+}
+
+</script>

--- a/apps/website/src/projects/components/project-backup/project-backup.vue
+++ b/apps/website/src/projects/components/project-backup/project-backup.vue
@@ -22,12 +22,15 @@
         >
           This project is currently view-only and cannot request exports or backups.
         </div>
-        <div class="text-flamingo mt-3">
+        <div
+          v-if="capabilities?.canBackup !== true"
+          class="text-flamingo mt-3"
+        >
           To request a full backup of this project, please send an email to jon@rfcx.org
         </div>
         <button
-          v-if="!isLoading"
-          class="btn btn-medium mt-6 hidden"
+          v-if="!isLoading && capabilities?.canBackup === true"
+          class="btn btn-medium mt-6"
           :class="!isAllowedToRequestNewBackup ? 'cursor-not-allowed btn-disabled' : 'btn-secondary'"
           type="button"
           :disabled="!isAllowedToRequestNewBackup || isPending"
@@ -40,8 +43,8 @@
           />
         </button>
         <span
-          v-if="!isAllowedToRequestNewBackup"
-          class="ml-4 text-xs text-util-gray-02 hidden"
+          v-if="capabilities?.canBackup === true && !isAllowedToRequestNewBackup"
+          class="ml-4 text-xs text-util-gray-02"
         >
           {{ TEXT_BACKUP_LIMIT }}
         </span>
@@ -69,6 +72,7 @@ import { computed, inject, ref } from 'vue'
 
 import { apiClientKey, togglesKey } from '@/globals'
 import { useStore } from '~/store'
+import { useGetProjectCapabilities } from '../../_composables/use-project-capabilities'
 import ProjectBackupModal from './components/backup-modal.vue'
 import ProjectBackupHistory from './components/project-backup-history-list.vue'
 import { useCreateBackup, useGetBackup } from './composables/use-project-backup'
@@ -78,6 +82,10 @@ const TEXT_BACKUP_LIMIT = 'You can request a backup every 7 days'
 const store = useStore()
 const toggles = inject(togglesKey)
 const isProjectViewOnly = computed(() => store.project?.isLocked === true)
+
+// Self-serve backup capability (2026-07-12, operator D3): server-computed
+// (super users always; owners/admins for small projects).
+const selectedProjectIdForCapabilities = computed(() => store.project?.id)
 
 const timeFrameLimit = computed(() => {
   const hours = toggles?.projectBackupTesting === true ? 0.25 : 7 * 24
@@ -107,6 +115,7 @@ const closeModal = () => {
 
 // API - GET backup history (loading state, success, error)
 const apiClientBio = inject(apiClientKey) as AxiosInstance
+const { data: capabilities } = useGetProjectCapabilities(apiClientBio, selectedProjectIdForCapabilities)
 const { data, error, isLoading, refetch: refetchList } = useGetBackup(apiClientBio, store.project?.id ?? -1)
 
 // API - POST request backup (loading state, success, error)

--- a/apps/website/src/projects/components/project-state-badge.vue
+++ b/apps/website/src/projects/components/project-state-badge.vue
@@ -18,7 +18,7 @@
              group-hover:opacity-100 group-hover:visible
              left-1/2 -translate-x-1/2 bottom-full mb-2 w-max whitespace-nowrap"
       >
-        This project is now View Only due to inactivity. Upgrade your plan to restore access.
+        This project is currently view-only. Contact support to restore access.
         <div
           class="tooltip-arrow duration-300"
           data-popper-arrow

--- a/apps/website/src/projects/entitlement-helpers.ts
+++ b/apps/website/src/projects/entitlement-helpers.ts
@@ -40,21 +40,14 @@ export const getProjectTypeCreateDescription = (projectType: ProjectType): strin
 }
 
 export const getProjectTypeUsageLimits = (projectType: ProjectType): ProjectUsageLimitSummary => {
-  if (projectType === 'premium' || projectType === 'unlimited') {
-    return {
-      recordingMinutesCount: null,
-      collaboratorCount: 20,
-      guestCount: null,
-      jobCount: null,
-      jobRecordingCount: null
-    }
-  }
-
+  // Tier rollback (2026-07-12): all limits are unlimited for every project
+  // type. This client-side fallback must never be tighter than the server
+  // (bio-api project_type_limit rows, which are all NULL).
   return {
-    recordingMinutesCount: 526000,
-    collaboratorCount: 3,
+    recordingMinutesCount: null,
+    collaboratorCount: null,
     guestCount: null,
     jobCount: null,
-    jobRecordingCount: 12000
+    jobRecordingCount: null
   }
 }

--- a/apps/website/src/projects/project-member-page.vue
+++ b/apps/website/src/projects/project-member-page.vue
@@ -345,16 +345,9 @@ const addNewUserError = ref(false)
 const userSearchValue = ref('')
 
 const disableText = computed(() => {
+  // Tier rollback (2026-07-12): member limits removed; no upgrade messaging.
   if (projectInfo.value?.isLocked === true) {
-    return 'This project is now View Only due to inactivity. Upgrade your plan to restore access.'
-  }
-
-  const projectType = projectInfo.value?.projectType ?? 'free'
-  const collabs = projectInfo.value?.usage?.collaboratorCount ?? 0
-  const guests = projectInfo.value?.usage?.guestCount ?? 0
-  const currentTotal = collabs + guests
-  if (projectType === 'free' || (projectType === 'premium' && currentTotal >= 7)) {
-    return 'Limit reached. Upgrade your plan to unlock this feature.'
+    return 'This project is currently view-only.'
   }
   if (!store.userIsAdminProjectMember) {
     return 'You do not have permission to add members.'
@@ -445,20 +438,13 @@ const memberLimitMessage = computed(() => {
 })
 
 const canAddMember = computed(() => {
+  // Tier rollback (2026-07-12): member limits removed. Previously this
+  // hardcoded `false` for free projects (blocking ALL member adds — stricter
+  // than the server ever was) and capped premium at 7 combined members
+  // (server allowed 20 collaborators + unlimited guests). The server-side
+  // guard (assertProjectMemberUpdateAllowed) remains the authority and
+  // no-ops now that project_type_limit values are NULL.
   if (projectInfo.value?.isLocked === true) return false
-
-  const projectType = projectInfo.value?.projectType ?? 'free'
-  const collabs = projectInfo.value?.usage?.collaboratorCount ?? 0
-  const guests = projectInfo.value?.usage?.guestCount ?? 0
-  const currentTotal = collabs + guests
-  if (projectType === 'free') {
-    return false
-  }
-
-  if (projectType === 'premium') {
-    return currentTotal < 7
-  }
-
   return true
 })
 

--- a/apps/website/src/projects/project-settings-page.vue
+++ b/apps/website/src/projects/project-settings-page.vue
@@ -113,9 +113,18 @@
             :is-create-project="false"
             @emit-project-listed="toggleListedProject"
           />
-          <template v-if="isToggledForBackup && store.userIsAdminProjectMember">
+          <template v-if="(isToggledForBackup || capabilities?.canBackup === true) && store.userIsAdminProjectMember">
             <hr class="border-util-gray-03 my-6">
             <project-backup />
+          </template>
+          <template v-if="capabilities?.canDelete === true">
+            <hr class="border-util-gray-03 my-6">
+            <project-delete
+              :is-deleting="isDeletingProject"
+              :is-error="isErrorDeleteProject"
+              :is-success="isSuccessDeleteProject"
+              @emit-project-delete="onEmitProjectDelete"
+            />
           </template>
         </div>
       </div>
@@ -127,6 +136,7 @@ import { type AxiosError, type AxiosInstance } from 'axios'
 import { computed, inject, ref, watch } from 'vue'
 import { onBeforeRouteLeave, useRouter } from 'vue-router'
 
+import { apiLegacySoftProjectDelete, apiLegacySoftSitesDelete } from '@rfcx-bio/common/api-arbimon/audiodata/sites'
 import { type ProjectProfileUpdateBody, ERROR_MESSAGE_UPDATE_PROJECT_SLUG_NOT_UNIQUE } from '@rfcx-bio/common/api-bio/project/project-settings'
 import { dayjs } from '@rfcx-bio/utils/dayjs-initialized'
 import { isValidSlug } from '@rfcx-bio/utils/string/slug'
@@ -134,11 +144,14 @@ import { isValidSlug } from '@rfcx-bio/utils/string/slug'
 import SaveStatusText from '@/_components/save-status-text.vue'
 import ReadOnlyBanner from '@/_layout/components/guest-banner/guest-banner.vue'
 import { urlWrapper } from '@/_services/images/url-wrapper'
-import { apiClientKey, togglesKey } from '@/globals'
+import { apiClientArbimonLegacyKey, apiClientKey, togglesKey } from '@/globals'
 import ProjectStateBadge from '@/projects/components/project-state-badge.vue'
+import { ROUTE_NAMES } from '~/router'
 import { useDashboardStore, useStore } from '~/store'
-import { useGetProjectSettings, useUpdateProjectImage, useUpdateProjectSettings } from './_composables/use-project-profile'
+import { useGetProjectCapabilities } from './_composables/use-project-capabilities'
+import { useDeleteProject, useGetProjectSettings, useUpdateProjectImage, useUpdateProjectSettings } from './_composables/use-project-profile'
 import { verifyDateFormError } from './components/form/functions'
+import ProjectDelete from './components/form/project-delete.vue'
 import ProjectForm from './components/form/project-form.vue'
 import ProjectImageForm from './components/form/project-image-form.vue'
 import ProjectListedForm from './components/form/project-listed-form.vue'
@@ -159,6 +172,25 @@ const selectedProjectId = computed(() => store.project?.id)
 const { data: settings, isError: isErrorSetting } = useGetProjectSettings(apiClientBio, selectedProjectId)
 const { mutate: mutateProjectSettings } = useUpdateProjectSettings(apiClientBio, store.project?.id ?? -1)
 const { mutate: mutatePatchProfilePhoto } = useUpdateProjectImage(apiClientBio, store.project?.id ?? -1)
+
+// Self-serve delete/backup (2026-07-12, operator D3): capabilities are
+// computed server-side (super users always; owners/admins for small projects
+// under the recording-count thresholds).
+const apiClientArbimon = inject(apiClientArbimonLegacyKey) as AxiosInstance
+const { data: capabilities } = useGetProjectCapabilities(apiClientBio, selectedProjectId)
+const selectedProjectSlug = computed(() => store.project?.slug)
+const { isPending: isDeletingProject, isError: isErrorDeleteProject, isSuccess: isSuccessDeleteProject, mutate: mutateDeleteProject } = useDeleteProject(apiClientBio)
+
+const onEmitProjectDelete = () => {
+  mutateDeleteProject(store.project?.id ?? -1, {
+    onSuccess: async () => {
+      await apiLegacySoftProjectDelete(apiClientArbimon, selectedProjectSlug.value ?? '')
+      await apiLegacySoftSitesDelete(apiClientArbimon, selectedProjectSlug.value ?? '')
+      store.deleteProject(store.project?.id)
+      await router.push({ name: ROUTE_NAMES.myProjects })
+    }
+  })
+}
 
 const newName = ref('')
 const dateStart = ref<string | null>(null)

--- a/packages/common/src/api-bio/project/project-capabilities.ts
+++ b/packages/common/src/api-bio/project/project-capabilities.ts
@@ -1,0 +1,23 @@
+import { type AxiosInstance } from 'axios'
+
+import { PROJECT_SPECIFIC_ROUTE_PREFIX } from '../_helpers'
+
+/**
+ * Self-serve project capabilities (2026-07-12): whether the CURRENT user can
+ * delete / request a backup of the project. Super users can always; regular
+ * owners/admins can when the project is small enough (recording-count
+ * thresholds, operator-adjustable via env on bio-api).
+ */
+export interface ProjectCapabilitiesResponse {
+  canDelete: boolean
+  canBackup: boolean
+  recordingCount: number | null
+  deleteMaxRecordings: number
+  backupMaxRecordings: number
+}
+
+export const projectCapabilitiesRoute = `${PROJECT_SPECIFIC_ROUTE_PREFIX}/capabilities`
+
+export const apiBioGetProjectCapabilities = async (apiClient: AxiosInstance, projectId: number): Promise<ProjectCapabilitiesResponse> => {
+  return await apiClient.get<ProjectCapabilitiesResponse>(`/projects/${projectId}/capabilities`).then(res => res.data)
+}


### PR DESCRIPTION
Operator-directed rollback (2026-07-12) of all pricing/user-tier limitations for normal Arbimon usage.

**DB migration `260712-01-rollback-tier-limits`** (idempotent): all `project_type_limit` + `account_tier_project_limit` values -> NULL (unlimited); all `is_locked` -> FALSE (255 rows). Every server-side guard (bio-api asserts, legacy 12k/300k job-recording guard, ingest upload quota) no-ops on NULL — restores pre-tiering behavior. Defaults in code follow (fresh seed can't re-tighten).

**Client bug fixes** (blocks the server never imposed): free projects couldn't add ANY member via UI; PM create card disabled at retired 50/200 job caps; premium member UI cap 7-combined vs server 20/∞; 'Upgrade your plan' copy dropped.

**Self-serve delete/backup** (replaces the super-only gate while keeping super access): owners can delete projects ≤ `PROJECT_DELETE_MAX_RECORDINGS` (default 60) recordings; owners/admins can request backups ≤ `PROJECT_BACKUP_MAX_RECORDINGS` (default 100). Env-var thresholds, fail-closed on unknown count. New `GET /projects/:projectId/capabilities`; Danger Zone + backup button restored in settings, gated on it.

Checks: tsc --build (api/cli/common), vue-tsc, eslint, prettier all green. Int tests updated for the new authz semantics.

Ref: rfcx-local OPEN-ITEMS #51 + `runbooks/AUDIT-arbimon-tier-limitations-rollback-plan-2026-07-12.md`