### PR TITLE
Admin URLs: /admin/projects + /admin/users; /tiers redirects

### DIFF
--- a/apps/website/src/_services/router/index.ts
+++ b/apps/website/src/_services/router/index.ts
@@ -274,17 +274,25 @@ const routes: RouteRecordRaw[] = [
     ]
   },
   {
+    // Admin (super-user) project/user management. The page is the former
+    // /tiers page; the active tab is driven by the route.
+    path: '/admin/projects',
+    name: ROUTE_NAMES.adminProjects,
+    component: PAGES.Tiers,
+    beforeEnter: [authRequiredGuard]
+  },
+  {
+    path: '/admin/users',
+    name: ROUTE_NAMES.adminUsers,
+    component: PAGES.Tiers,
+    beforeEnter: [authRequiredGuard]
+  },
+  {
+    // Legacy URL: /tiers -> /admin/projects (kept as a named redirect so
+    // old links and any { name: ROUTE_NAMES.tier } navigations still work).
     path: '/tiers',
     name: ROUTE_NAMES.tier,
-    component: PAGES.Tiers,
-    beforeEnter: [authRequiredGuard],
-    children: [
-      {
-        path: '',
-        name: ROUTE_NAMES.tierPage,
-        component: PAGES.Tiers
-      }
-    ]
+    redirect: { name: ROUTE_NAMES.adminProjects }
   },
   {
     path: '/:pathMatch(.*)*',

--- a/apps/website/src/_services/router/route-names.ts
+++ b/apps/website/src/_services/router/route-names.ts
@@ -49,6 +49,10 @@ export const ROUTE_NAMES = {
   mySpecies: 'my-species',
   pricing: 'pricing',
   pricingNew: 'pricing_new',
+  // Admin (super-user) pages. 'tier'/'tierPage' kept as legacy aliases so old
+  // { name: ROUTE_NAMES.tier } navigations still resolve (they redirect).
+  adminProjects: 'admin_projects',
+  adminUsers: 'admin_users',
   tier: 'tier',
   tierPage: 'tier-page'
 } as const

--- a/apps/website/src/super/project/tiers-page.vue
+++ b/apps/website/src/super/project/tiers-page.vue
@@ -2,14 +2,14 @@
   <div class="px-4 sm:px-6 py-8 lg:(pt-6 px-20) bg-white dark:bg-pitch">
     <div class="mx-auto max-w-screen-xl pt-4 md:pt-10">
       <h1 class="mb-6">
-        Manage Project and User Tiers
+        Manage Projects and Users
       </h1>
       <div class="mb-3 flex gap-2 border-b border-util-gray-03">
         <button
           type="button"
           class="px-4 py-3 text-sm font-medium"
           :class="activeTab === 'projects' ? 'text-frequency border-b-2 border-frequency' : 'text-subtle'"
-          @click="activeTab = 'projects'"
+          @click="selectTab('projects')"
         >
           Projects
         </button>
@@ -17,7 +17,7 @@
           type="button"
           class="px-4 py-3 text-sm font-medium"
           :class="activeTab === 'users' ? 'text-frequency border-b-2 border-frequency' : 'text-subtle'"
-          @click="activeTab = 'users'"
+          @click="selectTab('users')"
         >
           Users
         </button>
@@ -159,7 +159,7 @@
 import { useDebounce } from '@vueuse/core'
 import { type AxiosInstance } from 'axios'
 import { computed, inject, ref, watch } from 'vue'
-import { useRouter } from 'vue-router'
+import { useRoute, useRouter } from 'vue-router'
 
 import { type SuperProjectSummary, type SuperUserSummary } from '@rfcx-bio/common/api-bio/super/projects'
 
@@ -172,10 +172,25 @@ import UserTieringTable from './components/user-tiering-table.vue'
 
 const apiClientBio = inject(apiClientKey) as AxiosInstance
 const router = useRouter()
+const route = useRoute()
 const superStore = useSuperStore()
 
 const PAGE_SIZE = 25
-const activeTab = ref<'projects' | 'users'>('projects')
+// The active tab is ROUTE-DRIVEN: /admin/projects and /admin/users are two
+// named routes over this same page. Clicking a tab navigates (so the URL is
+// shareable/bookmarkable); the route change updates the tab.
+const routeTab = (): 'projects' | 'users' => route.name === ROUTE_NAMES.adminUsers ? 'users' : 'projects'
+const activeTab = ref<'projects' | 'users'>(routeTab())
+
+const selectTab = (tab: 'projects' | 'users'): void => {
+  void router.push({ name: tab === 'users' ? ROUTE_NAMES.adminUsers : ROUTE_NAMES.adminProjects })
+}
+
+watch(() => route.name, () => {
+  if (route.name === ROUTE_NAMES.adminProjects || route.name === ROUTE_NAMES.adminUsers) {
+    activeTab.value = routeTab()
+  }
+})
 const searchKeyword = ref('')
 const limit = ref(PAGE_SIZE)
 const offset = ref(0)


### PR DESCRIPTION
Operator request: move the admin-gated project/user management page under /admin/*.

- `/admin/projects` + `/admin/users` = new named routes over the former /tiers page; **active tab is route-driven** (clicking a tab navigates; URLs shareable).
- `/tiers` kept as a named redirect → `/admin/projects`.
- Title: 'Manage Project and User Tiers' → 'Manage Projects and Users'.

Deploys together with:
- rfcx-local public-router change (exact-match `/admin/projects`+`/admin/users` → Vue website; 301 `/tiers`; rest of `/admin/*` stays on the legacy AngularJS admin)
- rfcx/arbimon-legacy PR (its admin frontend calls the JSON lists at `/admin/projects/` + `/admin/users/` with trailing slash, which stay routed to legacy)